### PR TITLE
Add `npm link` to test CI

### DIFF
--- a/.github/workflows/nodejs-unittest.yml
+++ b/.github/workflows/nodejs-unittest.yml
@@ -24,6 +24,9 @@ jobs:
       - name: Install Dependencies
         run: npm install
         working-directory: ./javascript
+      - name: Create symlink
+        run: npm link
+        working-directory: ./javascript
       - name: Build package
         run: npm run build --if-present
         working-directory: ./javascript


### PR DESCRIPTION
To test cli in npm, I added `npm link` to CI.
ref: #20 & [its run](https://github.com/google/budoux/actions/runs/1514797795)