### PR TITLE
Add custom help formatter and shorthand of `--thres`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ __pycache__
 *.log
 *.egg-info
 
+# Python related files
+build/
+
 # JavaScript related files
 node_modules
 demo/static/app.js

--- a/budoux/main.py
+++ b/budoux/main.py
@@ -28,6 +28,11 @@ import budoux
 ArgList = typing.Optional[typing.List[str]]
 
 
+class BudouxHelpFormatter(argparse.ArgumentDefaultsHelpFormatter,
+                          argparse.RawDescriptionHelpFormatter):
+  pass
+
+
 def check_file(path: str) -> str:
   """Check if filepath is exist or not.
 
@@ -57,11 +62,11 @@ def parse_args(test: ArgList = None) -> argparse.Namespace:
   """
   parser = argparse.ArgumentParser(
       prog="budoux",
-      formatter_class=(lambda prog: argparse.RawDescriptionHelpFormatter(
+      formatter_class=(lambda prog: BudouxHelpFormatter(
           prog,
           **{
               "width": shutil.get_terminal_size(fallback=(120, 50)).columns,
-              "max_help_position": 25,
+              "max_help_position": 30,
           },
       )),
       description=textwrap.dedent("""\
@@ -82,7 +87,7 @@ def parse_args(test: ArgList = None) -> argparse.Namespace:
       metavar="JSON",
       type=check_file,
       default=pkg_resources.resource_filename(__name__, "models/ja-knbc.json"),
-      help="custom model file path (default: models/ja-knbc.json)",
+      help="custom model file path",
   )
   parser.add_argument(
       "-d",
@@ -90,7 +95,14 @@ def parse_args(test: ArgList = None) -> argparse.Namespace:
       metavar="STR",
       type=str,
       default="---",
-      help="output delimiter in TEXT mode (default: '---')",
+      help="output delimiter in TEXT mode",
+  )
+  parser.add_argument(
+      "-t",
+      "--thres",
+      type=int,
+      default=budoux.DEFAULT_THRES,
+      help="threshold value to separate chunks",
   )
   parser.add_argument(
       "-V",
@@ -98,12 +110,6 @@ def parse_args(test: ArgList = None) -> argparse.Namespace:
       action="version",
       version="%(prog)s {}".format(budoux.__version__),
   )
-  parser.add_argument(
-      "--thres",
-      type=int,
-      default=budoux.DEFAULT_THRES,
-      help="threshold value to separate chunks (default: {})".format(
-          budoux.DEFAULT_THRES))
   if test is not None:
     return parser.parse_args(test)
   else:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -107,9 +107,9 @@ class TestTextArguments(unittest.TestCase):
     self.assertEqual(cm.exception.code, 2)
 
   def test_cmdargs_thres(self):
-    cmdargs = ['--thres=0', '今日はとても天気です。']
+    cmdargs = ['--thres', '0', '今日はとても天気です。']
     output_granular = main._main(cmdargs)
-    cmdargs = ['--thres=10000000', '今日はとても天気です。']
+    cmdargs = ['--thres', '10000000', '今日はとても天気です。']
     output_whole = main._main(cmdargs)
     self.assertGreater(
         len(output_granular), len(output_whole),


### PR DESCRIPTION
```shellsession
$ budoux -h
usage: budoux [-h] [-H] [-m JSON] [-d STR] [-t THRES] [-V] [TXT]

BudouX is the successor to Budou,
the machine learning powered line break organizer tool.

positional arguments:
  TXT                      text (default: None)

optional arguments:
  -h, --help               show this help message and exit
  -H, --html               HTML mode (default: False)
  -m JSON, --model JSON    custom model file path (default: /Users/eggplants/prog/budoux/budoux/models/ja-knbc.json)
  -d STR, --delim STR      output delimiter in TEXT mode (default: ---)
  -t THRES, --thres THRES  threshold value to separate chunks (default: 1000)
  -V, --version            show program's version number and exit

```