### PR TITLE
Specify python required version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,7 @@ classifiers =
     Programming Language :: Python :: 3.10
 
 [options]
+python_requires= >= 3.7
 packages = find:
 include_package_data = True
 test_suite = tests


### PR DESCRIPTION
I have added a specifier of Python required version. (`>= 3.7`)