### PR TITLE
Add chunk-size option to reduce memory for model training

### DIFF
--- a/scripts/train.py
+++ b/scripts/train.py
@@ -118,9 +118,13 @@ def split_dataset(
   return X_train, X_test, Y_train, Y_test
 
 
-def fit(X: npt.NDArray[np.bool_], Y: npt.NDArray[np.bool_],
-        features: typing.List[str], iters: int, weights_filename: str,
-        log_filename: str, chunk_size: typing.Optional[int] = None) -> typing.Dict[int, float]:
+def fit(X: npt.NDArray[np.bool_],
+        Y: npt.NDArray[np.bool_],
+        features: typing.List[str],
+        iters: int,
+        weights_filename: str,
+        log_filename: str,
+        chunk_size: typing.Optional[int] = None) -> typing.Dict[int, float]:
   """Trains an AdaBoost classifier.
 
   Args:
@@ -154,10 +158,10 @@ def fit(X: npt.NDArray[np.bool_], Y: npt.NDArray[np.bool_],
     else:
       res = np.zeros(M_train)
       for i in range(0, N_train, chunk_size):
-          Y_train_chunk = Y_train[i:i + chunk_size]
-          X_train_chunk = X_train[i:i + chunk_size]
-          w_chunk = w[i:i + chunk_size]
-          res += w_chunk.dot(Y_train_chunk[:, None] ^ X_train_chunk)
+        Y_train_chunk = Y_train[i:i + chunk_size]
+        X_train_chunk = X_train[i:i + chunk_size]
+        w_chunk = w[i:i + chunk_size]
+        res += w_chunk.dot(Y_train_chunk[:, None] ^ X_train_chunk)
       res = res / w.sum()
     err = 0.5 - np.abs(res - 0.5)
     m_best = int(err.argmin())
@@ -207,7 +211,8 @@ def parse_args() -> argparse.Namespace:
       default=10000)
   parser.add_argument(
       '--chunk-size',
-      help='A chunk size to split training entries into chunks for memory reduction when calculating AdaBoost\'s weighted training error.')
+      help='A chunk size to split training entries into chunks for memory reduction when calculating AdaBoost\'s weighted training error.'
+  )
 
   return parser.parse_args()
 

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -120,7 +120,7 @@ def split_dataset(
 
 def fit(X: npt.NDArray[np.bool_], Y: npt.NDArray[np.bool_],
         features: typing.List[str], iters: int, weights_filename: str,
-        log_filename: str) -> typing.Dict[int, float]:
+        log_filename: str, chunk_size: typing.Optional[int] = None) -> typing.Dict[int, float]:
   """Trains an AdaBoost classifier.
 
   Args:
@@ -130,6 +130,8 @@ def fit(X: npt.NDArray[np.bool_], Y: npt.NDArray[np.bool_],
     iters (int): A number of training iterations.
     weights_filename (str): A file path to write the learned weights.
     log_filename (str): A file path to log the accuracy along with training.
+    chunk_size (Optional[int]): A chunk size to split training entries into chunks for memory reduction
+      when calculating AdaBoost's weighted training error.
 
   Returns:
     phi (Dict[int, float]): Leanred child classifiers.
@@ -142,12 +144,21 @@ def fit(X: npt.NDArray[np.bool_], Y: npt.NDArray[np.bool_],
 
   phis: typing.Dict[int, float] = dict()
   X_train, X_test, Y_train, Y_test = split_dataset(X, Y)
-  N_train, _ = X_train.shape
+  N_train, M_train = X_train.shape
   w = np.ones(N_train) / N_train
 
   for t in range(iters):
     print('=== %s ===' % (t))
-    res: npt.NDArray[np.float64] = w.dot(Y_train[:, None] ^ X_train) / w.sum()
+    if chunk_size is None:
+      res: npt.NDArray[np.float64] = w.dot(Y_train[:, None] ^ X_train) / w.sum()
+    else:
+      res = np.zeros(M_train)
+      for i in range(0, N_train, chunk_size):
+          Y_train_chunk = Y_train[i:i + chunk_size]
+          X_train_chunk = X_train[i:i + chunk_size]
+          w_chunk = w[i:i + chunk_size]
+          res += w_chunk.dot(Y_train_chunk[:, None] ^ X_train_chunk)
+      res = res / w.sum()
     err = 0.5 - np.abs(res - 0.5)
     m_best = int(err.argmin())
     pol_best = res[m_best] < 0.5
@@ -194,6 +205,9 @@ def parse_args() -> argparse.Namespace:
       '--iter',
       help='Number of iterations for training. (default: 10000)',
       default=10000)
+  parser.add_argument(
+      '--chunk-size',
+      help='A chunk size to split training entries into chunks for memory reduction when calculating AdaBoost\'s weighted training error.')
 
   return parser.parse_args()
 
@@ -205,9 +219,10 @@ def main() -> None:
   log_filename = args.log
   feature_thres = int(args.feature_thres)
   iterations = int(args.iter)
+  chunk_size = int(args.chunk_size) if args.chunk_size is not None else None
 
   X, Y, features = preprocess(train_data_filename, feature_thres)
-  fit(X, Y, features, iterations, weights_filename, log_filename)
+  fit(X, Y, features, iterations, weights_filename, log_filename, chunk_size)
 
   print('Training done. Export the model by passing %s to build_model.py' %
         (weights_filename))


### PR DESCRIPTION
## Background

I'm building BudouX custom model by using own large data. However the process was killed because of out of memory issue.

```
numpy.core._exceptions.MemoryError: Unable to allocate 23.6 GiB for an array with shape (146516, 21604) and data type float64
```

I found the cause of the error was due to the following calculation of training error. Numpy allocated a large amount of memory which was beyond the capacity of the machine, when multiplying matrices.

```
res: npt.NDArray[np.float64] = w.dot(Y_train[:, None] ^ X_train) / w.sum()
```

https://github.com/google/budoux/blob/main/scripts/train.py#L150

## Workaround

My idea is to split the matrix into chunks so that it can allocate small memory without crash.

Before
![image](https://user-images.githubusercontent.com/2387508/151136904-08a8aaff-b320-438d-b334-ab136a074d82.png)

After (L is chunk size, M is the number of chunks)

![image](https://user-images.githubusercontent.com/2387508/151136948-3caf75c7-761b-45f9-bad5-77808a9955d5.png)

## Concerns

A small difference in training error was observed due to floating point calculation error. The results of my model training with knbc data are shown below. You can see that digits are different after 16th decimal point.

```
# Before
=== 3343 ===
min error:	 0.49477815785410395
best tree:	 2129
training accuracy:	 0.9657460739427952
testing accuracy:	 0.9669472751439965

# After with chunk_size option (chunk_size = 1000)
=== 3343 ===
min error:	 0.49477815785410373
best tree:	 2129
training accuracy:	 0.9657460739427952
testing accuracy:	 0.9669472751439965
```

I'm looking forward to seeing your feedback. I'm happy to modify my code if needed.