### PR TITLE
`--lang` option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ __pycache__
 *.egg-info
 *,cover
 *.coverage
-xov.xml
+cov.xml
 
 # Python related files
 build/

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@ __pycache__
 *.pyc
 *.log
 *.egg-info
-*,cover
 *.coverage
 cov.xml
 

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ __pycache__
 *.pyc
 *.log
 *.egg-info
+*,cover
+*.coverage
 
 # Python related files
 build/

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ __pycache__
 *.egg-info
 *,cover
 *.coverage
+xov.xml
 
 # Python related files
 build/

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ $ budoux 本日は晴天です。  # default: japanese
 本日は
 晴天です。
 
-$ budoux -l zh 今天天气晴朗。
+$ budoux -l zh-hans 今天天气晴朗。
 今天天气
 晴朗。
 ```
@@ -129,15 +129,15 @@ positional arguments:
 options:
   -h, --help               show this help message and exit
   -H, --html               HTML mode (default: False)
-  -m JSON, --model JSON    custom model file path (default: /home/eggplants/prog/budoux/budoux/models/ja-knbc.json)
+  -m JSON, --model JSON    custom model file path (default: /path/to/models/ja-knbc.json)
   -l LANG, --lang LANG     language of custom model (default: None)
   -d STR, --delim STR      output delimiter in TEXT mode (default: ---)
   -t THRES, --thres THRES  threshold value to separate chunks (default: 1000)
   -V, --version            show program's version number and exit
 
 supported languages of `-l`, `--lang`:
-- zh
-- ja
+- zh-hans
+- ja-knbc
 ```
 
 ## Caveat

--- a/README.md
+++ b/README.md
@@ -91,7 +91,11 @@ For more details of the JavaScript model, please refer to [JavaScript module REA
 You can also format inputs on your terminal with `budoux` command.
 
 ```shellsession
-$ budoux 本日は晴天です。  # default: japanese
+$ budoux 本日は晴天です。 # default: japanese
+本日は
+晴天です。
+
+$ budoux -l ja 本日は晴天です。
 本日は
 晴天です。
 
@@ -137,7 +141,7 @@ options:
 
 supported languages of `-l`, `--lang`:
 - zh-hans
-- ja-knbc
+- ja
 ```
 
 ## Caveat

--- a/README.md
+++ b/README.md
@@ -91,9 +91,13 @@ For more details of the JavaScript model, please refer to [JavaScript module REA
 You can also format inputs on your terminal with `budoux` command.
 
 ```shellsession
-$ budoux 本日は晴天です。
+$ budoux 本日は晴天です。  # default: japanese
 本日は
 晴天です。
+
+$ budoux -l zh 今天天气晴朗。
+今天天气
+晴朗。
 ```
 
 ```shellsession
@@ -114,7 +118,7 @@ If you want to see help, run `budoux -h`.
 
 ```shellsession
 $ budoux -h
-usage: budoux [-h] [-H] [-m JSON] [-d STR] [-t THRES] [-V] [TXT]
+usage: budoux [-h] [-H] [-m JSON | -l LANG] [-d STR] [-t THRES] [-V] [TXT]
 
 BudouX is the successor to Budou,
 the machine learning powered line break organizer tool.
@@ -122,13 +126,18 @@ the machine learning powered line break organizer tool.
 positional arguments:
   TXT                      text (default: None)
 
-optional arguments:
+options:
   -h, --help               show this help message and exit
   -H, --html               HTML mode (default: False)
-  -m JSON, --model JSON    custom model file path (default: /path/to/models/ja-knbc.json)
+  -m JSON, --model JSON    custom model file path (default: /home/eggplants/prog/budoux/budoux/models/ja-knbc.json)
+  -l LANG, --lang LANG     language of custom model (default: None)
   -d STR, --delim STR      output delimiter in TEXT mode (default: ---)
   -t THRES, --thres THRES  threshold value to separate chunks (default: 1000)
   -V, --version            show program's version number and exit
+
+supported languages of `-l`, `--lang`:
+- zh
+- ja
 ```
 
 ## Caveat

--- a/budoux/feature_extractor.py
+++ b/budoux/feature_extractor.py
@@ -20,7 +20,7 @@ import os
 import sys
 import typing
 
-from .utils import SEP, INVALID, Result
+from .utils import INVALID, SEP, Result
 
 with open(os.path.join(os.path.dirname(__file__), 'unicode_blocks.json')) as f:
   block_starts: typing.List[int] = json.load(f)

--- a/budoux/main.py
+++ b/budoux/main.py
@@ -63,9 +63,11 @@ def get_model_langs() -> typing.Dict[str, str]:
   langs = {}
   for model in models:
     model_name = model.split(os.sep)[-1][:-5]
-    langs[model_name if model_name.startswith('zh-') else model_name[:2]] = model
-  else:
-    return langs
+    if model_name.startswith('zh-'):
+      langs[model_name] = model
+    else:
+      langs[model_name[:2]] = model
+  return langs
 
 
 def check_lang(lang: str) -> str:

--- a/budoux/main.py
+++ b/budoux/main.py
@@ -80,7 +80,8 @@ def check_lang(lang: str) -> str:
     return langs[lang]
   else:
     raise argparse.ArgumentTypeError(
-        f"'{lang}' does not exist in builtin models.")
+        f"'{lang}' does not exist in builtin models. (supported languages: {langs.keys()})"
+    )
 
 
 def parse_args(test: ArgList = None) -> argparse.Namespace:

--- a/budoux/main.py
+++ b/budoux/main.py
@@ -60,14 +60,14 @@ def get_model_langs() -> typing.Dict[str, str]:
   """
   models = glob.glob(
       pkg_resources.resource_filename(__name__, "models") + "/*-*.json")
-  return {model.split(os.sep)[-1][:2]: model for model in models}
+  return {model.split(os.sep)[-1][:-5]: model for model in models}
 
 
 def check_lang(lang: str) -> str:
   """Check if given language exists or not.
 
   Args:
-      lang (str): language code (e.g.: 'ja')
+      lang (str): language code (e.g.: 'ja-knbc')
 
   Raises:
       argparse.ArgumentTypeError: Raise if no model for given language exists.

--- a/budoux/main.py
+++ b/budoux/main.py
@@ -60,14 +60,19 @@ def get_model_langs() -> typing.Dict[str, str]:
   """
   models = glob.glob(
       pkg_resources.resource_filename(__name__, "models") + "/*-*.json")
-  return {model.split(os.sep)[-1][:-5]: model for model in models}
+  langs = {}
+  for model in models:
+    model_name = model.split(os.sep)[-1][:-5]
+    langs[model_name if model_name.startswith('zh-') else model_name[:2]] = model
+  else:
+    return langs
 
 
 def check_lang(lang: str) -> str:
   """Check if given language exists or not.
 
   Args:
-      lang (str): language code (e.g.: 'ja-knbc')
+      lang (str): language code (e.g.: 'ja')
 
   Raises:
       argparse.ArgumentTypeError: Raise if no model for given language exists.

--- a/budoux/main.py
+++ b/budoux/main.py
@@ -14,13 +14,13 @@
 # limitations under the License.
 """BudouX Script to provide CLI for user."""
 import argparse
+import glob
 import json
 import os
 import shutil
 import sys
 import textwrap
 import typing
-import glob
 
 import pkg_resources
 
@@ -60,7 +60,7 @@ def get_model_langs() -> typing.Dict[str, str]:
   """
   models = glob.glob(
       pkg_resources.resource_filename(__name__, "models") + "/*-*.json")
-  return {model.split("/")[-1][:2]: model for model in models}
+  return {model.split(os.sep)[-1][:2]: model for model in models}
 
 
 def check_lang(lang: str) -> str:

--- a/budoux/main.py
+++ b/budoux/main.py
@@ -80,7 +80,7 @@ def check_lang(lang: str) -> str:
     return langs[lang]
   else:
     raise argparse.ArgumentTypeError(
-        f"'{lang}' does not exist in builtin models. (supported languages: {langs.keys()})"
+        f"'{lang}' does not exist in builtin models. (supported languages: {list(langs.keys())})"
     )
 
 

--- a/budoux/main.py
+++ b/budoux/main.py
@@ -160,7 +160,8 @@ def parse_args(test: ArgList = None) -> argparse.Namespace:
 
 def _main(test: ArgList = None) -> str:
   args = parse_args(test=test)
-  with open(args.lang or args.model, "r") as f:
+  model_path = args.lang or args.model
+  with open(model_path, "r") as f:
     model = json.load(f)
 
   parser = budoux.Parser(model)

--- a/budoux/parser.py
+++ b/budoux/parser.py
@@ -19,7 +19,7 @@ import typing
 from html.parser import HTMLParser
 
 from .feature_extractor import get_feature
-from .utils import SEP, INVALID, Result
+from .utils import INVALID, SEP, Result
 
 MODEL_DIR = os.path.join(os.path.dirname(__file__), 'models')
 PARENT_CSS_STYLE = 'word-break: keep-all; overflow-wrap: break-word;'

--- a/javascript/README.md
+++ b/javascript/README.md
@@ -133,19 +133,20 @@ If you want to see help, run `budoux -h`.
 
 ```shellsession
 $ budoux -h
-Usage: budoux [-h] [-H] [-m JSON] [-d STR] [-V] [TXT]
+Usage: budoux [-h] [-H] [-d STR] [-t THRES] [-m JSON] [-V] [TXT]
 
 BudouX is the successor to Budou, the machine learning powered line break organizer tool.
 
 Arguments:
-  txt                 text
+  txt                   text
 
 Options:
-  -H, --html          HTML mode
-  -d, --delim <str>   output delimiter in TEXT mode (default: "---")
-  -m, --model <json>  custom model file path
-  -V, --version       output the version number
-  -h, --help          display help for command
+  -H, --html            HTML mode (default: false)
+  -d, --delim <str>     output delimiter in TEXT mode (default: "---")
+  -t, --thres <number>  threshold value to separate chunks (default: "1000")
+  -m, --model <json>    custom model file path
+  -V, --version         output the version number
+  -h, --help            display help for command
 ```
 
 ### Attributes

--- a/tests/test_feature_extractor.py
+++ b/tests/test_feature_extractor.py
@@ -26,10 +26,10 @@ sys.path.insert(0, os.path.abspath(LIB_PATH))
 
 from budoux import feature_extractor, utils  # noqa (module hack)
 
-if isinstance(sys.stdin, io.TextIOWrapper) and sys.version_info >= (3, 7):
+if isinstance(sys.stdin, io.TextIOWrapper):
   sys.stdin.reconfigure(encoding='utf-8')
 
-if isinstance(sys.stdout, io.TextIOWrapper) and sys.version_info >= (3, 7):
+if isinstance(sys.stdout, io.TextIOWrapper):
   sys.stdout.reconfigure(encoding='utf-8')
 
 SOURCE_FILE_PATH = os.path.abspath(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -55,6 +55,29 @@ class TestCommonOption(unittest.TestCase):
     self.assertEqual(cm.exception.code, 0)
 
 
+class TestModelOption(unittest.TestCase):
+
+  def test_cmdargs_invalid_json(self) -> None:
+    cmdargs = ['-m', '404.json']
+    with self.assertRaises(SystemExit) as cm:
+      main.parse_args(cmdargs)
+
+    self.assertEqual(cm.exception.code, 2)
+
+  def test_cmdargs_invalid_lang(self) -> None:
+    cmdargs = ['-l', 'aa']
+    with self.assertRaises(SystemExit) as cm:
+      main.parse_args(cmdargs)
+
+    self.assertEqual(cm.exception.code, 2)
+
+  def test_cmdargs_lang_ja(self) -> None:
+    cmdargs = ['-l', 'ja', '今日はいい天気ですね。']
+    output = main._main(cmdargs)
+
+    self.assertEqual(output, '今日は\nいい\n天気ですね。')
+
+
 class TestTextArguments(unittest.TestCase):
 
   def test_cmdargs_single_text(self) -> None:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -64,18 +64,31 @@ class TestModelOption(unittest.TestCase):
 
     self.assertEqual(cm.exception.code, 2)
 
-  def test_cmdargs_invalid_lang(self) -> None:
+  def test_cmdargs_invalid_lang_1(self) -> None:
     cmdargs = ['-l', 'aa']
     with self.assertRaises(SystemExit) as cm:
       main.parse_args(cmdargs)
 
     self.assertEqual(cm.exception.code, 2)
 
+  def test_cmdargs_invalid_lang_2(self) -> None:
+    cmdargs = ['-l', 'ja-knbc']
+    with self.assertRaises(SystemExit) as cm:
+      main.parse_args(cmdargs)
+
+    self.assertEqual(cm.exception.code, 2)
+
   def test_cmdargs_lang_ja(self) -> None:
-    cmdargs = ['-l', 'ja-knbc', '今日はいい天気ですね。']
+    cmdargs = ['-l', 'ja', '今日はいい天気ですね。']
     output = main._main(cmdargs)
 
     self.assertEqual(output, '今日は\nいい\n天気ですね。')
+
+  def test_cmdargs_lang_ja(self) -> None:
+    cmdargs = ['-l', 'zh-hans', '今天天气晴朗。']
+    output = main._main(cmdargs)
+
+    self.assertEqual(output, '今天天气\n晴朗。')
 
 
 class TestTextArguments(unittest.TestCase):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -72,7 +72,7 @@ class TestModelOption(unittest.TestCase):
     self.assertEqual(cm.exception.code, 2)
 
   def test_cmdargs_lang_ja(self) -> None:
-    cmdargs = ['-l', 'ja', '今日はいい天気ですね。']
+    cmdargs = ['-l', 'ja-knbc', '今日はいい天気ですね。']
     output = main._main(cmdargs)
 
     self.assertEqual(output, '今日は\nいい\n天気ですね。')

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -84,7 +84,7 @@ class TestModelOption(unittest.TestCase):
 
     self.assertEqual(output, '今日は\nいい\n天気ですね。')
 
-  def test_cmdargs_lang_ja(self) -> None:
+  def test_cmdargs_lang_zh_hans(self) -> None:
     cmdargs = ['-l', 'zh-hans', '今天天气晴朗。']
     output = main._main(cmdargs)
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -24,10 +24,10 @@ sys.path.insert(0, abspath(LIB_PATH))
 
 from budoux import main  # noqa (module hack)
 
-if isinstance(sys.stdin, io.TextIOWrapper) and sys.version_info >= (3, 7):
+if isinstance(sys.stdin, io.TextIOWrapper):
   sys.stdin.reconfigure(encoding='utf-8')
 
-if isinstance(sys.stdout, io.TextIOWrapper) and sys.version_info >= (3, 7):
+if isinstance(sys.stdout, io.TextIOWrapper):
   sys.stdout.reconfigure(encoding='utf-8')
 
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -145,11 +145,11 @@ class TestParser(unittest.TestCase):
 
 class TestDefaultParser(unittest.TestCase):
 
-  def test_load_default_japanese_parser(self):
+  def test_load_default_japanese_parser(self) -> None:
     p_ja = parser.load_default_japanese_parser()
     self.assertTrue("UW4:私" in p_ja.model)
 
-  def test_load_default_simplified_chinese_parser(self):
+  def test_load_default_simplified_chinese_parser(self) -> None:
     p_ch = parser.load_default_simplified_chinese_parser()
     self.assertTrue("UW4:力" in p_ch.model)
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -143,5 +143,16 @@ class TestParser(unittest.TestCase):
         'Should work with emojis.')
 
 
+class TestDefaultParser(unittest.TestCase):
+
+  def test_load_default_japanese_parser(self):
+    p_ja = parser.load_default_japanese_parser()
+    self.assertTrue("UW4:私" in p_ja.model)
+
+  def test_load_default_simplified_chinese_parser(self):
+    p_ch = parser.load_default_simplified_chinese_parser()
+    self.assertTrue("UW4:力" in p_ch.model)
+
+
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
I have added `-l`, `--lang` option to select a model by a language code.

---

```shellsession
$ budoux -l aa
usage: budoux [-h] [-H] [-m JSON | -l LANG] [-d STR] [-t THRES] [-V] [TXT]
budoux: error: argument -l/--lang: 'aa' does not exist in builtin models. (supported languages: ['zh', 'ja'])

$ budoux -l zh 今天天气晴朗。
今天天气
晴朗。

$ budoux -l ja -m budoux/models/ja-knbc.json 今日はいい天気ですね。
usage: budoux [-h] [-H] [-m JSON | -l LANG] [-d STR] [-t THRES] [-V] [TXT]
budoux: error: argument -m/--model: not allowed with argument -l/--lang
```