### PR TITLE
Change `applyElement` to call `HTMLProcessor`

### DIFF
--- a/javascript/README.md
+++ b/javascript/README.md
@@ -71,10 +71,10 @@ For example:
 ```javascript
 import { HTMLProcessor } from 'budoux';
 const ele = document.querySelector('p.budou-this');
-const html_processor = new HTMLProcessor(parser, {
+const htmlProcessor = new HTMLProcessor(parser, {
   separator: ' '
 });
-html_processor.applyToElement(ele);
+htmlProcessor.applyToElement(ele);
 ```
 
 [`HTMLProcessor`]: https://github.com/google/budoux/blob/main/javascript/src/html_processor.ts

--- a/javascript/README.md
+++ b/javascript/README.md
@@ -63,22 +63,19 @@ console.log(ele.outerHTML);
 // <p class="budou-this" style="word-break: keep-all; overflow-wrap: break-word;">今日は<b><wbr>とても<wbr>天気</b>です。</p>
 ```
 
-There is another way to apply the process to an HTML element.
+Internally, the `applyElement` calls the [`HTMLProcessor`] class
+with a `<wbr>` element as the separator.
+You can use the [`HTMLProcessor`] class directly if desired.
+For example:
 
 ```javascript
 import { HTMLProcessor } from 'budoux';
 const ele = document.querySelector('p.budou-this');
-const applier = new HTMLProcessor(parser);
-applier.applyToElement(ele);
+const html_processor = new HTMLProcessor(parser, {
+  separator: ' '
+});
+html_processor.applyToElement(ele);
 ```
-
-The [`HTMLProcessor`] class
-recognizes separate or nested paragraphs more correctly,
-its output is generally more memory efficient for browsers,
-and it can customize its output such as inserting a space at boundaries
-which is often useful for accessibility,
-but the bundle code size is larger.
-Please see the JSDoc for more details.
 
 [`HTMLProcessor`]: https://github.com/google/budoux/blob/main/javascript/src/html_processor.ts
 

--- a/javascript/src/parser.ts
+++ b/javascript/src/parser.ts
@@ -15,11 +15,11 @@
  */
 
 import {unicodeBlocks} from './data/unicode_blocks';
-import {skipNodes} from './data/skip_nodes';
 import {model as jaKNBCModel} from './data/models/ja-knbc';
 import {model as zhHansModel} from './data/models/zh-hans';
 import {parseFromString} from './dom';
-import {bisectRight, SEP, INVALID} from './utils';
+import {HTMLProcessor} from './html_processor';
+import {bisectRight, INVALID} from './utils';
 
 /**
  * The default threshold value for the parser.
@@ -32,8 +32,6 @@ const NODETYPE = {
   ELEMENT: 1,
   TEXT: 3,
 };
-
-const SKIP_NODES = new Set(skipNodes);
 
 export class Parser {
   model;
@@ -195,45 +193,11 @@ export class Parser {
    * @param threshold The threshold score to control the granularity of chunks.
    */
   applyElement(parentElement: HTMLElement, threshold = DEFAULT_THRES) {
-    parentElement.style.wordBreak = 'keep-all';
-    parentElement.style.overflowWrap = 'break-word';
-    const chunks = this.parse(parentElement.textContent || '', threshold);
-    let charsToProcess = chunks.join(SEP);
-    const ownerDocument = parentElement.ownerDocument;
-
-    const processChildren = (parent: HTMLElement) => {
-      const toSkip = SKIP_NODES.has(parent.nodeName);
-      const children = [...parent.childNodes];
-      for (const child of children) {
-        if (child.nodeType === NODETYPE.TEXT) {
-          let textNodeContent = '';
-          const nodesToAdd: (HTMLElement | Text)[] = [];
-          (child.textContent || '').split('').forEach(char => {
-            if (toSkip) {
-              textNodeContent += char;
-              charsToProcess = charsToProcess.slice(
-                charsToProcess[0] === SEP ? 2 : 1
-              );
-            } else if (char === charsToProcess[0]) {
-              textNodeContent += char;
-              charsToProcess = charsToProcess.slice(1);
-            } else if (charsToProcess[0] === SEP) {
-              nodesToAdd.push(ownerDocument.createTextNode(textNodeContent));
-              nodesToAdd.push(ownerDocument.createElement('wbr'));
-              charsToProcess = charsToProcess.slice(2);
-              textNodeContent = char;
-            }
-          });
-          if (textNodeContent) {
-            nodesToAdd.push(ownerDocument.createTextNode(textNodeContent));
-          }
-          child.replaceWith(...nodesToAdd);
-        } else if (child.nodeType === NODETYPE.ELEMENT) {
-          processChildren(child as HTMLElement);
-        }
-      }
-    };
-    processChildren(parentElement);
+    const html_processor = new HTMLProcessor(this, {
+      separator: parentElement.ownerDocument.createElement('wbr'),
+      threshold: threshold,
+    });
+    html_processor.applyToElement(parentElement);
   }
 
   /**

--- a/javascript/src/parser.ts
+++ b/javascript/src/parser.ts
@@ -193,11 +193,11 @@ export class Parser {
    * @param threshold The threshold score to control the granularity of chunks.
    */
   applyElement(parentElement: HTMLElement, threshold = DEFAULT_THRES) {
-    const html_processor = new HTMLProcessor(this, {
+    const htmlProcessor = new HTMLProcessor(this, {
       separator: parentElement.ownerDocument.createElement('wbr'),
       threshold: threshold,
     });
-    html_processor.applyToElement(parentElement);
+    htmlProcessor.applyToElement(parentElement);
   }
 
   /**

--- a/javascript/tests/test_html_processor.ts
+++ b/javascript/tests/test_html_processor.ts
@@ -84,6 +84,28 @@ describe('HTMLProcessor.applyToElement', () => {
   }
 });
 
+describe('HTMLProcessor.applyToElement.separator.node', () => {
+  const dom = new JSDOM('<div>今日は良い天気</div>');
+  const document = dom.window.document;
+  const separator = document.createElement('span');
+  separator.style.whiteSpace = 'normal';
+  separator.textContent = '\u200B';
+  const processor = new MockHTMLProcessorBase({
+    separator: separator,
+    className: 'applied',
+  });
+  processor.applyToElement(document.body);
+  it('should clone separator element deeply', () => {
+    expect(document.body.innerHTML).toEqual(
+      '<div class="applied">今日は' +
+        '<span style="white-space: normal;">\u200B</span>' +
+        '良い' +
+        '<span style="white-space: normal;">\u200B</span>' +
+        '天気</div>'
+    );
+  });
+});
+
 describe('HTMLProcessor.getBlocks', () => {
   const getBlocks = (html: string) => {
     const dom = new JSDOM(html);


### PR DESCRIPTION
This patch changes `Parser.applyElement` to call the `HTMLProcessor` class.

The `HTMLProcessorOptions.separator` is changed to accept a `Node`. This is because `undefined` had double meanings; i.e., use the default (ZWSP) and use the `<wbr>` element.