### PR TITLE
Add py.typed for static analysis with mypy

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include budoux/unicode_blocks.json
 include budoux/skip_nodes.json
+include budoux/py.typed
 recursive-include budoux/models *.json


### PR DESCRIPTION
The budoux source code contains type hints, but the following error occurs when using mypy.

```shell
$ cat main.py
import budoux
parser = budoux.load_default_japanese_parser()
$ mypy main.py
main.py:1: error: Skipping analyzing "budoux": module is installed, but missing library stubs or py.typed marker
main.py:1: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
Found 1 error in 1 file (checked 1 source file)
```

I added `py.typed` file according to the [URL](https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports) in the error message above.  After adding the file, the error no longer occurs as shown below.

```shell
$ mypy main.py
Success: no issues found in 1 source file
```