### PR TITLE
Add missing export for HTMLProcessor in index.ts

### DIFF
--- a/javascript/src/index.ts
+++ b/javascript/src/index.ts
@@ -15,3 +15,4 @@
  */
 
 export * from './parser.js';
+export {HTMLProcessor} from './html_processor.js';


### PR DESCRIPTION
Hi, I was experimenting with the library and wanted to do something with the HTMLProcessor as described 
[here](https://github.com/google/budoux/tree/main/javascript#applying-to-an-html-element)

However, it would not let me import and I believe it's because there is a missing export statement from `index.ts`.

Hence I added an extra line in.