### PR TITLE
Add validation data arg to train.py

### DIFF
--- a/scripts/tests/test_train.py
+++ b/scripts/tests/test_train.py
@@ -135,29 +135,6 @@ class TestPreprocess(unittest.TestCase):
     self.assertEqual(val_dataset.X_cols.tolist(), [])
 
 
-class TestSplitData(unittest.TestCase):
-
-  def test_standard_setup(self) -> None:
-    split_ratio = 0.6
-    X = np.array([
-        [0, 1, 0],
-        [1, 0, 0],
-        [1, 0, 1],
-        [0, 1, 1],
-        [0, 1, 0],
-    ])
-    Y = np.array([0, 1, 0, 1, 0], dtype=bool)
-    rows, cols = np.where(X == 1)
-    rows_train, cols_train, rows_test, cols_test, Y_train, Y_test = train.split_data(
-        rows, cols, Y, split_ratio)
-    self.assertEqual(rows_train.tolist(), [0, 1, 2, 2])
-    self.assertEqual(cols_train.tolist(), [1, 0, 0, 2])
-    self.assertEqual(rows_test.tolist(), [0, 0, 1])
-    self.assertEqual(cols_test.tolist(), [1, 2, 1])
-    self.assertEqual(Y_train.tolist(), [0, 1, 0])
-    self.assertEqual(Y_test.tolist(), [1, 0])
-
-
 class TestPred(unittest.TestCase):
 
   def test_standard_setup(self) -> None:

--- a/scripts/tests/test_train.py
+++ b/scripts/tests/test_train.py
@@ -91,7 +91,7 @@ class TestPreprocess(unittest.TestCase):
                '-1\txyz\n'
                '1\tabc\tqux\tfoo\n'))
     feature_thres = 1
-    train_dataset, val_dataset, features = train.preprocess(
+    train_dataset, features, val_dataset = train.preprocess(
         train_data_path, feature_thres, val_data_path)
 
     self.assertEqual(features, ['foo', 'bar', 'baz'])
@@ -124,7 +124,7 @@ class TestPreprocess(unittest.TestCase):
                '1\tbar\tfoo\n'
                '-1\tbaz\tqux\n'))
     features_thres = 1
-    train_dataset, val_dataset, features = train.preprocess(
+    train_dataset, features, val_dataset = train.preprocess(
         train_data_path, feature_thres)
     self.assertEqual(features, ['foo', 'bar', 'baz'])
     self.assertEqual(train_dataset.Y.tolist(), [True, False, True, True, False])

--- a/scripts/tests/test_train.py
+++ b/scripts/tests/test_train.py
@@ -127,8 +127,7 @@ class TestPreprocess(unittest.TestCase):
                '1\tfoo\tbar\tbaz\n'
                '1\tbar\tfoo\n'
                '-1\tbaz\tqux\n'))
-    train_dataset, features, val_dataset = train.preprocess(
-        train_data_path, 1)
+    train_dataset, features, val_dataset = train.preprocess(train_data_path, 1)
     self.assertEqual(features, ['foo', 'bar', 'baz'])
     self.assertEqual(train_dataset.Y.tolist(), [True, False, True, True, False])
     self.assertEqual(train_dataset.X_rows.tolist(), [0, 0, 1, 2, 2, 2, 3, 3, 4])

--- a/scripts/tests/test_train.py
+++ b/scripts/tests/test_train.py
@@ -282,5 +282,20 @@ class TestExtractFeatures(unittest.TestCase):
     result = train.extract_features(entries_file_path, 1)
     self.assertEqual(result, ['foo', 'bar', 'baz'])
 
+
+class TestLoadDataset(unittest.TestCase):
+  def test_with_standard_setup(self):
+    entries_file_path = tempfile.NamedTemporaryFile().name
+    with open(entries_file_path, 'w') as f:
+      f.write(('1\tfoo\tbar\n'
+               '-1\tfoo\n'
+               '1\tfoo\tbar\tbaz\n'
+               '1\tbar\tfoo\n'
+               '-1\tbaz\tqux\n'))
+    result = train.load_dataset(entries_file_path, {'foo': 0, 'bar': 1, 'baz': 2})
+    self.assertEqual(result.X_rows.tolist(), [0, 0, 1, 2, 2, 2, 3, 3, 4])
+    self.assertEqual(result.X_cols.tolist(), [0, 1, 0, 0, 1, 2, 1, 0, 2])
+    self.assertEqual(result.Y.tolist(), [True, False, True, True, False])
+
 if __name__ == '__main__':
   unittest.main()

--- a/scripts/tests/test_train.py
+++ b/scripts/tests/test_train.py
@@ -58,11 +58,12 @@ class TestArgParse(unittest.TestCase):
     self.assertEqual(output.feature_thres, train.DEFAULT_FEATURE_THRES)
     self.assertEqual(output.iter, train.DEFAULT_ITERATION)
     self.assertEqual(output.out_span, train.DEFAULT_OUT_SPAN)
+    self.assertEqual(output.val_data, None)
 
   def test_cmdargs_full(self) -> None:
     cmdargs = [
         'encoded.txt', '-o', 'out.txt', '--log', 'foo.log', '--feature-thres',
-        '100', '--iter', '10', '--out-span', '50'
+        '100', '--iter', '10', '--out-span', '50', '--val-data', 'val_encoded.txt'
     ]
     output = train.parse_args(cmdargs)
     self.assertEqual(output.encoded_train_data, 'encoded.txt')
@@ -71,6 +72,7 @@ class TestArgParse(unittest.TestCase):
     self.assertEqual(output.feature_thres, 100)
     self.assertEqual(output.iter, 10)
     self.assertEqual(output.out_span, 50)
+    self.assertEqual(output.val_data, 'val_encoded.txt')
 
 
 class TestPreprocess(unittest.TestCase):

--- a/scripts/tests/test_train.py
+++ b/scripts/tests/test_train.py
@@ -258,5 +258,29 @@ class TestFit(unittest.TestCase):
     os.remove(log_file_path)
 
 
+class TestExtractFeatures(unittest.TestCase):
+  def test_with_standard_setup(self):
+    entries_file_path = tempfile.NamedTemporaryFile().name
+    with open(entries_file_path, 'w') as f:
+      f.write(('1\tfoo\tbar\n'
+               '-1\tfoo\n'
+               '1\tfoo\tbar\tbaz\n'
+               '1\tbar\tfoo\n'
+               '-1\tbaz\tqux\n'))
+    result = train.extract_features(entries_file_path, 1)
+    self.assertEqual(result, ['foo', 'bar', 'baz'])
+
+  def test_with_redundant_breaks(self):
+    entries_file_path = tempfile.NamedTemporaryFile().name
+    with open(entries_file_path, 'w') as f:
+      f.write(('1\tfoo\tbar\n'
+               '-1\tfoo\n'
+               '1\tfoo\tbar\tbaz\n\n'
+               '1\tbar\tfoo\n'
+               '\n'
+               '-1\tbaz\tqux\n'))
+    result = train.extract_features(entries_file_path, 1)
+    self.assertEqual(result, ['foo', 'bar', 'baz'])
+
 if __name__ == '__main__':
   unittest.main()

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -369,7 +369,7 @@ def parse_args(test: ArgList = None) -> argparse.Namespace:
       default=DEFAULT_OUT_SPAN)
   parser.add_argument(
       '--val-data',
-      help=f'File path for the encoded validation data.',
+      help='File path for the encoded validation data.',
       type=str)
   if test is None:
     return parser.parse_args()

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -134,7 +134,8 @@ def preprocess(
   features = extract_features(train_data_path, feature_thres)
   feature_index = dict((feature, i) for i, feature in enumerate(features))
   train_dataset = load_dataset(train_data_path, feature_index)
-  val_dataset = load_dataset(val_data_path, feature_index) if val_data_path else None
+  val_dataset = load_dataset(val_data_path,
+                             feature_index) if val_data_path else None
   return train_dataset, features, val_dataset
 
 
@@ -255,11 +256,9 @@ def fit(dataset_train: Dataset, dataset_val: typing.Optional[Dataset],
   with open(weights_filename, 'w') as f:
     f.write('')
   with open(log_filename, 'w') as f:
-    f.write(
-        'iter\ttrain_accuracy\ttrain_precision\ttrain_recall\ttrain_fscore')
+    f.write('iter\ttrain_accuracy\ttrain_precision\ttrain_recall\ttrain_fscore')
     if dataset_val:
-      f.write(
-          '\ttest_accuracy\ttest_precision\ttest_recall\ttest_fscore')
+      f.write('\ttest_accuracy\ttest_precision\ttest_recall\ttest_fscore')
     f.write('\n')
   print('Outputting learned weights to %s ...' % (weights_filename))
 
@@ -368,9 +367,7 @@ def parse_args(test: ArgList = None) -> argparse.Namespace:
       type=int,
       default=DEFAULT_OUT_SPAN)
   parser.add_argument(
-      '--val-data',
-      help='File path for the encoded validation data.',
-      type=str)
+      '--val-data', help='File path for the encoded validation data.', type=str)
   if test is None:
     return parser.parse_args()
   else:

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -127,7 +127,7 @@ def preprocess(
     - features (List[str]): The list of features.
   """
   features = extract_features(entries_filename, feature_thres)
-  feature_index = dict([(feature, i) for i, feature in enumerate(features)])
+  feature_index = dict((feature, i) for i, feature in enumerate(features))
   dataset = load_dataset(entries_filename, feature_index)
   return dataset.X_rows, dataset.X_cols, dataset.Y, features
 

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -108,8 +108,8 @@ def load_dataset(data_path: str, findex: typing.Dict[str, int]) -> Dataset:
 def preprocess(
     train_data_path: str,
     feature_thres: int,
-    val_data_path: str,
-) -> typing.Tuple[typing.Any, typing.Any, typing.Any, typing.List[str]]:
+    val_data_path: typing.Optional[str],
+) -> typing.Tuple[Dataset, typing.List[str], typing.Optional[Dataset]]:
   """Loads entries and translates them into JAX arrays. The boolean matrix of
   the input data is represented by row indices and column indices of True values
   instead of the matrix itself for memory efficiency, assuming the matrix is

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -386,6 +386,10 @@ def parse_args(test: ArgList = None) -> argparse.Namespace:
       help=f'Iteration span to output metrics and weights. (default: {DEFAULT_OUT_SPAN})',
       type=int,
       default=DEFAULT_OUT_SPAN)
+  parser.add_argument(
+      '--val-data',
+      help=f'File path for the encoded validation data.',
+      type=str)
   if test is None:
     return parser.parse_args()
   else:
@@ -400,6 +404,7 @@ def main() -> None:
   feature_thres = int(args.feature_thres)
   iterations = int(args.iter)
   out_span = int(args.out_span)
+  val_data: typing.Optional[str] = args.val_data
 
   X_rows, X_cols, Y, features = preprocess(data_filename, feature_thres)
   X_rows_train, X_cols_train, X_rows_test, X_cols_test, Y_train, Y_test = split_data(


### PR DESCRIPTION
Allow users to pass the validation dataset separately, instead of splitting the dataset inside the training script.