### PR TITLE
Make scripts run without install

### DIFF
--- a/scripts/encode_data.py
+++ b/scripts/encode_data.py
@@ -17,10 +17,15 @@ import argparse
 import functools
 import itertools
 import multiprocessing
+import os
 import sys
 import typing
 
-from budoux import utils
+# module hack
+LIB_PATH = os.path.join(os.path.dirname(__file__), '..')
+sys.path.insert(0, os.path.abspath(LIB_PATH))
+
+from budoux import utils  # noqa (module hack)
 
 ArgList = typing.Optional[typing.List[str]]
 DEFAULT_OUTPUT_FILENAME = 'encoded_data.txt'

--- a/scripts/prepare_knbc.py
+++ b/scripts/prepare_knbc.py
@@ -26,10 +26,15 @@ $ python scripts/prepare_knbc.py KNBC_v1.0_090925_utf8 -o source_knbc.txt
 
 import argparse
 import os
+import sys
 import typing
 from html.parser import HTMLParser
 
-from budoux import utils
+# module hack
+LIB_PATH = os.path.join(os.path.dirname(__file__), '..')
+sys.path.insert(0, os.path.abspath(LIB_PATH))
+
+from budoux import utils  # noqa (module hack)
 
 
 class KNBCHTMLParser(HTMLParser):

--- a/scripts/tests/test_encode_data.py
+++ b/scripts/tests/test_encode_data.py
@@ -18,12 +18,11 @@ import sys
 import typing
 import unittest
 
-from budoux import utils
-
 # module hack
 LIB_PATH = os.path.join(os.path.dirname(__file__), '..', '..')
 sys.path.insert(0, os.path.abspath(LIB_PATH))
 
+from budoux import utils  # noqa (module hack)
 from scripts import encode_data  # noqa (module hack)
 
 


### PR DESCRIPTION
With this change, users don't need to run `pip install budoux` to run the scripts under the `scripts` directory anymore.