### PR TITLE
Support non-breaking content in java

### DIFF
--- a/budoux/skip_nodes.json
+++ b/budoux/skip_nodes.json
@@ -5,6 +5,7 @@
   "IFRAME",
   "INPUT",
   "META",
+  "NOBR",
   "SCRIPT",
   "STYLE",
   "TEXTAREA",

--- a/java/src/test/java/com/google/budoux/HTMLProcessorTest.java
+++ b/java/src/test/java/com/google/budoux/HTMLProcessorTest.java
@@ -51,12 +51,23 @@ public class HTMLProcessorTest {
 
   @Test
   public void testResolveWithNodesToSkip() {
-    List<String> phrases = Arrays.asList("abc", "def");
-    String html = "a<button>bcde</button>f";
+    List<String> phrases = Arrays.asList("abc", "def", "ghi");
+    String html = "a<button>bcde</button>fghi";
     String result = HTMLProcessor.resolve(phrases, html);
     assertEquals(
         "<span style=\"word-break: keep-all; overflow-wrap:"
-            + " anywhere;\">a<button>bcde</button>f</span>",
+            + " anywhere;\">a<button>bcde</button>f<wbr>ghi</span>",
+        result);
+  }
+
+  @Test
+  public void testResolveWithNodesBreakBeforeSkip() {
+    List<String> phrases = Arrays.asList("abc", "def", "ghi", "jkl");
+    String html = "abc<nobr>defghi</nobr>jkl";
+    String result = HTMLProcessor.resolve(phrases, html);
+    assertEquals(
+        "<span style=\"word-break: keep-all; overflow-wrap:"
+            + " anywhere;\">abc<wbr><nobr>defghi</nobr><wbr>jkl</span>",
         result);
   }
 


### PR DESCRIPTION
This patch supports non-breaking content in Java.

In Java and Python implementations, the "Skip" operation includes the skipped content to the BudouX parser, so no changes to the text for the parser is needed.

This patch changes following items:
1. Add `NOBR` to the "skip" element.
2. Fix "skip" is applied only to its descendants. Before this patch, all content following "skip" elements are skipped.
3. When there's a phrase boundary right before the "skip" element, insert a break before the "skip" element.