### PR TITLE
Support non-breaking content in Python

### DIFF
--- a/tests/test_html_processor.py
+++ b/tests/test_html_processor.py
@@ -64,10 +64,17 @@ class TestResolve(unittest.TestCase):
     self.assertEqual(result, expected)
 
   def test_with_nodes_to_skip(self) -> None:
-    chunks = ['abc', 'def']
-    html = "a<button>bcde</button>f"
+    chunks = ['abc', 'def', 'ghi']
+    html = "a<button>bcde</button>fghi"
     result = html_processor.resolve(chunks, html)
-    expected = '<span style="word-break: keep-all; overflow-wrap: anywhere;">a<button>bcde</button>f</span>'
+    expected = '<span style="word-break: keep-all; overflow-wrap: anywhere;">a<button>bcde</button>f<wbr>ghi</span>'
+    self.assertEqual(result, expected)
+
+  def test_with_break_before_skip(self) -> None:
+    chunks = ['abc', 'def', 'ghi', 'jkl']
+    html = "abc<button>defghi</button>jkl"
+    result = html_processor.resolve(chunks, html)
+    expected = '<span style="word-break: keep-all; overflow-wrap: anywhere;">abc<wbr><button>defghi</button><wbr>jkl</span>'
     self.assertEqual(result, expected)
 
   def test_with_nothing_to_split(self) -> None:

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -70,9 +70,12 @@ class TestParser(unittest.TestCase):
     )
 
     input_html = 'xyz<script>alert(1);</script>xyzabc'
+    # TODO: Because the content for skip elements are included, this test tries
+    # to break before "alert". We may want to distinguish "skip from the
+    # content" and "skip breaking" in future.
     expected_html = (
         '<span style="word-break: keep-all; overflow-wrap: anywhere;">'
-        'xyz<script>alert(1);</script>xyz<wbr>abc</span>')
+        'xyz<wbr><script>alert(1);</script>xyz<wbr>abc</span>')
     output_html = p.translate_html_string(input_html)
     self.assertEqual(output_html, expected_html,
                      'Should pass script tags as is.')
@@ -80,7 +83,7 @@ class TestParser(unittest.TestCase):
     input_html = 'xyz<code>abc</code>abc'
     expected_html = (
         '<span style="word-break: keep-all; overflow-wrap: anywhere;">'
-        'xyz<code>abc</code><wbr>abc</span>')
+        'xyz<wbr><code>abc</code><wbr>abc</span>')
     output_html = p.translate_html_string(input_html)
     self.assertEqual(output_html, expected_html,
                      'Should skip some specific tags.')


### PR DESCRIPTION
This patch supports non-breaking content in Python.

In Java and Python implementations, the "Skip" operation includes the skipped content to the BudouX parser, so no changes to the text for the parser is needed.

This patch changes following items:
1. Changed `to_skip` to a stack of elements, rather than always reset to `False` at the end of an element.
2. When there's a phrase boundary right before the "skip" element, insert a break before the "skip" element.

Note `<NOBR>` is added to `skip_nodes.json` at: https://github.com/google/budoux/pull/248.