### PR TITLE
Move hasChildTextNode to HTML Processor

### DIFF
--- a/javascript/src/html_processor.ts
+++ b/javascript/src/html_processor.ts
@@ -153,6 +153,13 @@ const defaultBlockElements = new Set([
   'MARQUEE',
 ]);
 
+// We could use `Node.TEXT_NODE` and `Node.ELEMENT_NODE` in a browser context,
+// but we define the same here for Node.js environments.
+const NODETYPE = {
+  ELEMENT: 1,
+  TEXT: 3,
+};
+
 /**
  * Determine the action for an element.
  * @param element An element to determine the action for.
@@ -313,6 +320,19 @@ export class HTMLProcessor {
       if (options.className !== undefined) this.className = options.className;
       if (options.separator !== undefined) this.separator = options.separator;
     }
+  }
+
+  /**
+   * Checks if the given element has a text node in its children.
+   *
+   * @param ele An element to be checked.
+   * @returns Whether the element has a child text node.
+   */
+  static hasChildTextNode(ele: HTMLElement) {
+    for (const child of ele.childNodes) {
+      if (child.nodeType === NODETYPE.TEXT) return true;
+    }
+    return false;
   }
 
   /**
@@ -538,7 +558,7 @@ function HTMLProcessing<TBase extends Constructor<Parser>>(Base: TBase) {
     translateHTMLString(html: string) {
       if (html === '') return html;
       const doc = parseFromString(html);
-      if (Parser.hasChildTextNode(doc.body)) {
+      if (HTMLProcessor.hasChildTextNode(doc.body)) {
         const wrapper = doc.createElement('span');
         wrapper.append(...doc.body.childNodes);
         doc.body.append(wrapper);

--- a/javascript/src/parser.ts
+++ b/javascript/src/parser.ts
@@ -14,13 +14,6 @@
  * limitations under the License.
  */
 
-// We could use `Node.TEXT_NODE` and `Node.ELEMENT_NODE` in a browser context,
-// but we define the same here for Node.js environments.
-const NODETYPE = {
-  ELEMENT: 1,
-  TEXT: 3,
-};
-
 /**
  * Base BudouX parser.
  */
@@ -36,19 +29,6 @@ export class Parser {
     this.model = new Map(
       Object.entries(model).map(([k, v]) => [k, new Map(Object.entries(v))])
     );
-  }
-
-  /**
-   * Checks if the given element has a text node in its children.
-   *
-   * @param ele An element to be checked.
-   * @returns Whether the element has a child text node.
-   */
-  static hasChildTextNode(ele: HTMLElement) {
-    for (const child of ele.childNodes) {
-      if (child.nodeType === NODETYPE.TEXT) return true;
-    }
-    return false;
   }
 
   /**


### PR DESCRIPTION
Move hasChildTextNode from Parser to HTML Processor because HTML Processor is the only user of the static method.