### PR TITLE
Use ZWSP instead of WBR

### DIFF
--- a/budoux/html_processor.py
+++ b/budoux/html_processor.py
@@ -49,16 +49,16 @@ class HTMLChunkResolver(HTMLParser):
   """
   output = ''
 
-  def __init__(self, chunks: typing.List[str], segmenter: str):
+  def __init__(self, chunks: typing.List[str], separator: str):
     """Initializes the parser.
 
     Args:
       chunks (List[str]): The chunks to resolve.
-      segmenter (str): The segmenter string.
+      separator (str): The separator string.
     """
     HTMLParser.__init__(self)
     self.chunks_joined = SEP.join(chunks)
-    self.segmenter = segmenter
+    self.separator = separator
     self.to_skip = False
     self.scan_index = 0
     self.element_stack: queue.LifoQueue[bool] = queue.LifoQueue()
@@ -75,7 +75,7 @@ class HTMLChunkResolver(HTMLParser):
     if tag.upper() in SKIP_NODES:
       if not self.to_skip and self.chunks_joined[self.scan_index] == SEP:
         self.scan_index += 1
-        self.output += self.segmenter
+        self.output += self.separator
       self.to_skip = True
     self.output += '<%s%s>' % (tag, encoded_attrs)
 
@@ -87,7 +87,7 @@ class HTMLChunkResolver(HTMLParser):
     for char in data:
       if not char == self.chunks_joined[self.scan_index]:
         if not self.to_skip:
-          self.output += self.segmenter
+          self.output += self.separator
         self.scan_index += 1
       self.output += char
       self.scan_index += 1
@@ -109,18 +109,18 @@ def get_text(html: str) -> str:
 
 def resolve(phrases: typing.List[str],
             html: str,
-            segmenter: str = '\u200b') -> str:
+            separator: str = '\u200b') -> str:
   """Wraps phrases in the HTML string with non-breaking markup.
 
   Args:
     phrases (List[str]): The phrases included in the HTML string.
     html (str): The HTML string to resolve.
-    segmenter (str, optional): The segmenter string.
+    separator (str, optional): The separator string.
 
   Returns:
     The HTML string with phrases wrapped in non-breaking markup.
   """
-  resolver = HTMLChunkResolver(phrases, segmenter)
+  resolver = HTMLChunkResolver(phrases, separator)
   resolver.feed(html)
   result = '<span style="%s">%s</span>' % (PARENT_CSS_STYLE, resolver.output)
   return result

--- a/demo/src/app.ts
+++ b/demo/src/app.ts
@@ -59,7 +59,7 @@ const run = () => {
   const renderWithBR = brCheckElement.checked;
   if (renderWithBR) {
     outputContainerElement.innerHTML = window.DOMPurify.sanitize(
-      outputContainerElement.innerHTML.replace(/<wbr>/g, '<br>'));
+      outputContainerElement.innerHTML.replace(/\u200b/g, '<br>'));
   }
 };
 

--- a/java/src/main/java/com/google/budoux/HTMLProcessor.java
+++ b/java/src/main/java/com/google/budoux/HTMLProcessor.java
@@ -59,12 +59,14 @@ final class HTMLProcessor {
   private static class PhraseResolvingNodeVisitor implements NodeVisitor {
     private static final char SEP = '\uFFFF';
     private final String phrasesJoined;
+    private final String separator;
     private final StringBuilder output = new StringBuilder();
     private Integer scanIndex = 0;
     private boolean toSkip = false;
     private Stack<Boolean> elementStack = new Stack<Boolean>();
 
-    PhraseResolvingNodeVisitor(List<String> phrases) {
+    PhraseResolvingNodeVisitor(List<String> phrases, String separator) {
+      this.separator = separator;
       this.phrasesJoined = String.join(Character.toString(SEP), phrases);
     }
 
@@ -86,7 +88,7 @@ final class HTMLProcessor {
         final String nodeName = node.nodeName();
         if (skipNodes.contains(nodeName.toUpperCase(Locale.ENGLISH))) {
           if (!toSkip && phrasesJoined.charAt(scanIndex) == SEP) {
-            output.append("<wbr>");
+            output.append(separator);
             scanIndex++;
           }
           toSkip = true;
@@ -98,7 +100,7 @@ final class HTMLProcessor {
           char c = data.charAt(i);
           if (c != phrasesJoined.charAt(scanIndex)) {
             if (!toSkip) {
-              output.append("<wbr>");
+              output.append(separator);
             }
             scanIndex++;
           }
@@ -126,9 +128,9 @@ final class HTMLProcessor {
    * @param html the HTML string to resolve.
    * @return the HTML string of phrases wrapped in non-breaking markup.
    */
-  public static String resolve(List<String> phrases, String html) {
+  public static String resolve(List<String> phrases, String html, String separator) {
     Document doc = Jsoup.parseBodyFragment(html);
-    PhraseResolvingNodeVisitor nodeVisitor = new PhraseResolvingNodeVisitor(phrases);
+    PhraseResolvingNodeVisitor nodeVisitor = new PhraseResolvingNodeVisitor(phrases, separator);
     doc.body().traverse(nodeVisitor);
     return String.format("<span style=\"%s\">%s</span>", STYLE, nodeVisitor.getOutput());
   }

--- a/java/src/main/java/com/google/budoux/HTMLProcessor.java
+++ b/java/src/main/java/com/google/budoux/HTMLProcessor.java
@@ -78,6 +78,7 @@ final class HTMLProcessor {
 
     /**
      * Returns the resolved output string.
+     *
      * @return the output string.
      */
     public StringBuilder getOutput() {

--- a/java/src/main/java/com/google/budoux/HTMLProcessor.java
+++ b/java/src/main/java/com/google/budoux/HTMLProcessor.java
@@ -139,6 +139,18 @@ final class HTMLProcessor {
    * @param html the HTML string to resolve.
    * @return the HTML string of phrases wrapped in non-breaking markup.
    */
+  public static String resolve(List<String> phrases, String html) {
+    return resolve(phrases, html, "\u200b");
+  }
+
+  /**
+   * Wraps phrases in the HTML string with non-breaking markup.
+   *
+   * @param phrases the phrases included in the HTML string.
+   * @param html the HTML string to resolve.
+   * @param separator the separator string.
+   * @return the HTML string of phrases wrapped in non-breaking markup.
+   */
   public static String resolve(List<String> phrases, String html, String separator) {
     Document doc = Jsoup.parseBodyFragment(html);
     PhraseResolvingNodeVisitor nodeVisitor = new PhraseResolvingNodeVisitor(phrases, separator);

--- a/java/src/main/java/com/google/budoux/HTMLProcessor.java
+++ b/java/src/main/java/com/google/budoux/HTMLProcessor.java
@@ -65,11 +65,21 @@ final class HTMLProcessor {
     private boolean toSkip = false;
     private Stack<Boolean> elementStack = new Stack<Boolean>();
 
+    /**
+     * Constructs a PhraseResolvingNodeVisitor.
+     *
+     * @param phrases a list of phrase strings.
+     * @param separator the separator string.
+     */
     PhraseResolvingNodeVisitor(List<String> phrases, String separator) {
       this.separator = separator;
       this.phrasesJoined = String.join(Character.toString(SEP), phrases);
     }
 
+    /**
+     * Returns the resolved output string.
+     * @return the output string.
+     */
     public StringBuilder getOutput() {
       return output;
     }

--- a/java/src/main/java/com/google/budoux/Parser.java
+++ b/java/src/main/java/com/google/budoux/Parser.java
@@ -183,6 +183,6 @@ public class Parser {
   public String translateHTMLString(String html) {
     String sentence = HTMLProcessor.getText(html);
     List<String> phrases = parse(sentence);
-    return HTMLProcessor.resolve(phrases, html);
+    return HTMLProcessor.resolve(phrases, html, "\u200b");
   }
 }

--- a/java/src/test/java/com/google/budoux/HTMLProcessorTest.java
+++ b/java/src/test/java/com/google/budoux/HTMLProcessorTest.java
@@ -32,7 +32,7 @@ public class HTMLProcessorTest {
   public void testResolveWithSimpleTextInput() {
     List<String> phrases = Arrays.asList("abc", "def");
     String html = "abcdef";
-    String result = HTMLProcessor.resolve(phrases, html);
+    String result = HTMLProcessor.resolve(phrases, html, "<wbr>");
     assertEquals(
         "<span style=\"word-break: keep-all; overflow-wrap: anywhere;\">abc<wbr>def</span>",
         result);
@@ -42,7 +42,7 @@ public class HTMLProcessorTest {
   public void testResolveWithStandardHTMLInput() {
     List<String> phrases = Arrays.asList("abc", "def");
     String html = "ab<a href=\"http://example.com\">cd</a>ef";
-    String result = HTMLProcessor.resolve(phrases, html);
+    String result = HTMLProcessor.resolve(phrases, html, "<wbr>");
     assertEquals(
         "<span style=\"word-break: keep-all; overflow-wrap: anywhere;\">ab<a"
             + " href=\"http://example.com\">c<wbr>d</a>ef</span>",
@@ -53,7 +53,7 @@ public class HTMLProcessorTest {
   public void testResolveWithNodesToSkip() {
     List<String> phrases = Arrays.asList("abc", "def", "ghi");
     String html = "a<button>bcde</button>fghi";
-    String result = HTMLProcessor.resolve(phrases, html);
+    String result = HTMLProcessor.resolve(phrases, html, "<wbr>");
     assertEquals(
         "<span style=\"word-break: keep-all; overflow-wrap:"
             + " anywhere;\">a<button>bcde</button>f<wbr>ghi</span>",
@@ -64,7 +64,7 @@ public class HTMLProcessorTest {
   public void testResolveWithNodesBreakBeforeSkip() {
     List<String> phrases = Arrays.asList("abc", "def", "ghi", "jkl");
     String html = "abc<nobr>defghi</nobr>jkl";
-    String result = HTMLProcessor.resolve(phrases, html);
+    String result = HTMLProcessor.resolve(phrases, html, "<wbr>");
     assertEquals(
         "<span style=\"word-break: keep-all; overflow-wrap:"
             + " anywhere;\">abc<wbr><nobr>defghi</nobr><wbr>jkl</span>",
@@ -75,7 +75,7 @@ public class HTMLProcessorTest {
   public void testResolveWithNothingToSplit() {
     List<String> phrases = Arrays.asList("abcdef");
     String html = "abcdef";
-    String result = HTMLProcessor.resolve(phrases, html);
+    String result = HTMLProcessor.resolve(phrases, html, "<wbr>");
     assertEquals(
         "<span style=\"word-break: keep-all; overflow-wrap: anywhere;\">abcdef</span>", result);
   }

--- a/java/src/test/java/com/google/budoux/ParserTest.java
+++ b/java/src/test/java/com/google/budoux/ParserTest.java
@@ -61,7 +61,7 @@ public class ParserTest {
     String result = parser.translateHTMLString(html);
     assertEquals(
         "<span style=\"word-break: keep-all; overflow-wrap: anywhere;\"><a"
-            + " href=\"http://example.com\">xyz<wbr>a</a>bc</span>",
+            + " href=\"http://example.com\">xyz\u200ba</a>bc</span>",
         result);
   }
 }

--- a/javascript/src/tests/test_cli.ts
+++ b/javascript/src/tests/test_cli.ts
@@ -48,7 +48,7 @@ describe('cli', () => {
     const inputText = '今日は天気です。';
     const argv = ['node', 'budoux', '--html', inputText];
     const expectedStdOut =
-      '<span style="word-break: keep-all; overflow-wrap: anywhere;">今日は<wbr>天気です。</span>';
+      '<span style="word-break: keep-all; overflow-wrap: anywhere;">今日は\u200B天気です。</span>';
     cli(argv);
     expect(console.log).toHaveBeenCalledWith(expectedStdOut);
   });
@@ -57,7 +57,7 @@ describe('cli', () => {
     const inputText = '今日は天気です。';
     const argv = ['node', 'budoux', '-H', inputText];
     const expectedStdOut =
-      '<span style="word-break: keep-all; overflow-wrap: anywhere;">今日は<wbr>天気です。</span>';
+      '<span style="word-break: keep-all; overflow-wrap: anywhere;">今日は\u200B天気です。</span>';
     cli(argv);
     expect(console.log).toHaveBeenCalledWith(expectedStdOut);
   });

--- a/javascript/src/tests/test_html_processor.ts
+++ b/javascript/src/tests/test_html_processor.ts
@@ -332,35 +332,35 @@ describe('HTMLProcessingParser.applyElement', () => {
   };
   const style = 'word-break: keep-all; overflow-wrap: anywhere;';
 
-  it('should insert WBR tags where the sentence should break.', () => {
+  it('should insert ZWSPs where the sentence should break.', () => {
     const inputHTML = '<p>xyzabcabc</p>';
-    const expectedHTML = `<p style="${style}">xyz<wbr>abc<wbr>abc</p>`;
+    const expectedHTML = `<p style="${style}">xyz\u200Babc\u200Babc</p>`;
     const model = {
       UW4: {a: 1001}, // means "should separate right before 'a'".
     };
     checkEqual(model, inputHTML, expectedHTML);
   });
 
-  it('should insert WBR tags even it overlaps with other HTML tags.', () => {
+  it('should insert ZWSPs even it overlaps with other HTML tags.', () => {
     const inputHTML = '<p>xy<a href="#">zabca</a>bc</p>';
-    const expectedHTML = `<p style="${style}">xy<a href="#">z<wbr>abc<wbr>a</a>bc</p>`;
+    const expectedHTML = `<p style="${style}">xy<a href="#">z\u200Babc\u200Ba</a>bc</p>`;
     const model = {
       UW4: {a: 1001}, // means "should separate right before 'a'".
     };
     checkEqual(model, inputHTML, expectedHTML);
   });
 
-  it('should not insert WBR tags to where input has WBR tags.', () => {
+  it('should not insert ZWSPs to where input has WBR tags already.', () => {
     const inputHTML = '<p>xyz<wbr>abcabc</p>';
-    const expectedHTML = `<p style="${style}">xyz<wbr>abc<wbr>abc</p>`;
+    const expectedHTML = `<p style="${style}">xyz<wbr>abc\u200Babc</p>`;
     const model = {
       UW4: {a: 1001}, // means "should separate right before 'a'".
     };
     checkEqual(model, inputHTML, expectedHTML);
   });
-  it('should not insert WBR tags to where input has ZWSP.', () => {
+  it('should not insert ZWSPs to where input has ZWSPs.', () => {
     const inputHTML = '<p>xyz\u200Babcabc</p>';
-    const expectedHTML = `<p style="${style}">xyz\u200babc<wbr>abc</p>`;
+    const expectedHTML = `<p style="${style}">xyz\u200babc\u200Babc</p>`;
     const model = {
       UW4: {a: 1001}, // means "should separate right before 'a'".
     };
@@ -387,7 +387,7 @@ describe('HTMLProcessingParser.translateHTMLString', () => {
   it('should output a html string with a SPAN parent with proper style attributes.', () => {
     const inputHTML = 'xyzabcd';
     const expectedHTML = `
-    <span style="word-break: keep-all; overflow-wrap: anywhere;">xyz<wbr>abcd</span>`;
+    <span style="word-break: keep-all; overflow-wrap: anywhere;">xyz\u200Babcd</span>`;
     checkEqual(defaultModel, inputHTML, expectedHTML);
   });
 
@@ -396,7 +396,7 @@ describe('HTMLProcessingParser.translateHTMLString', () => {
     const expectedHTML = `
     <p class="foo"
        style="color: red; word-break: keep-all; overflow-wrap: anywhere;"
-    >xyz<wbr>abcd</p>`;
+    >xyz\u200Babcd</p>`;
     checkEqual(defaultModel, inputHTML, expectedHTML);
   });
 
@@ -410,7 +410,7 @@ describe('HTMLProcessingParser.translateHTMLString', () => {
     const inputHTML = 'xyz<script>alert(1);</script>xyzabc';
     const expectedHTML = `<span
     style="word-break: keep-all; overflow-wrap: anywhere;"
-    >xyz<script>alert(1);</script>xyz<wbr>abc</span>`;
+    >xyz<script>alert(1);</script>xyz\u200Babc</span>`;
     checkEqual(defaultModel, inputHTML, expectedHTML);
   });
 
@@ -418,7 +418,7 @@ describe('HTMLProcessingParser.translateHTMLString', () => {
     const inputHTML = '<script>alert(1);</script>xyzabc';
     const expectedHTML = `<span
     style="word-break: keep-all; overflow-wrap: anywhere;"
-    >xyz<wbr>abc</span>`;
+    >xyz\u200Babc</span>`;
     checkEqual(defaultModel, inputHTML, expectedHTML);
   });
 
@@ -426,7 +426,7 @@ describe('HTMLProcessingParser.translateHTMLString', () => {
     const inputHTML = 'xyz<code>abc</code>abc';
     const expectedHTML = `<span
     style="word-break: keep-all; overflow-wrap: anywhere;"
-    >xyz<code>abc</code><wbr>abc</span>`;
+    >xyz<code>abc</code>\u200Babc</span>`;
     checkEqual(defaultModel, inputHTML, expectedHTML);
   });
 
@@ -434,7 +434,7 @@ describe('HTMLProcessingParser.translateHTMLString', () => {
     const inputHTML = 'xyza<a href="#" hidden>bc</a>abc';
     const expectedHTML = `<span
     style="word-break: keep-all; overflow-wrap: anywhere;"
-    >xyz<wbr>a<a href="#" hidden>bc</a><wbr>abc</span>`;
+    >xyz\u200Ba<a href="#" hidden>bc</a>\u200Babc</span>`;
     checkEqual(defaultModel, inputHTML, expectedHTML);
   });
 
@@ -442,7 +442,7 @@ describe('HTMLProcessingParser.translateHTMLString', () => {
     const inputHTML = 'xyza🇯🇵🇵🇹abc';
     const expectedHTML = `<span
     style="word-break: keep-all; overflow-wrap: anywhere;"
-    >xyz<wbr>a🇯🇵🇵🇹<wbr>abc</span>`;
+    >xyz\u200Ba🇯🇵🇵🇹\u200Babc</span>`;
     checkEqual(defaultModel, inputHTML, expectedHTML);
   });
 });

--- a/tests/test_html_processor.py
+++ b/tests/test_html_processor.py
@@ -41,7 +41,7 @@ class TestHTMLChunkResolver(unittest.TestCase):
   def test_output(self) -> None:
     input = '<p>ab<b>cde</b>f</p>'
     expected = '<p>ab<b>c<wbr>de</b>f</p>'
-    resolver = html_processor.HTMLChunkResolver(['abc', 'def'])
+    resolver = html_processor.HTMLChunkResolver(['abc', 'def'], '<wbr>')
     resolver.feed(input)
     self.assertEqual(resolver.output, expected,
                      'WBR tags should be inserted as specified by chunks.')
@@ -53,28 +53,28 @@ class TestResolve(unittest.TestCase):
     chunks = ['abc', 'def']
     html = 'abcdef'
     result = html_processor.resolve(chunks, html)
-    expected = '<span style="word-break: keep-all; overflow-wrap: anywhere;">abc<wbr>def</span>'
+    expected = '<span style="word-break: keep-all; overflow-wrap: anywhere;">abc\u200bdef</span>'
     self.assertEqual(result, expected)
 
   def test_with_standard_html_input(self) -> None:
     chunks = ['abc', 'def']
     html = 'ab<a href="http://example.com">cd</a>ef'
     result = html_processor.resolve(chunks, html)
-    expected = '<span style="word-break: keep-all; overflow-wrap: anywhere;">ab<a href="http://example.com">c<wbr>d</a>ef</span>'
+    expected = '<span style="word-break: keep-all; overflow-wrap: anywhere;">ab<a href="http://example.com">c\u200bd</a>ef</span>'
     self.assertEqual(result, expected)
 
   def test_with_nodes_to_skip(self) -> None:
     chunks = ['abc', 'def', 'ghi']
     html = "a<button>bcde</button>fghi"
     result = html_processor.resolve(chunks, html)
-    expected = '<span style="word-break: keep-all; overflow-wrap: anywhere;">a<button>bcde</button>f<wbr>ghi</span>'
+    expected = '<span style="word-break: keep-all; overflow-wrap: anywhere;">a<button>bcde</button>f\u200bghi</span>'
     self.assertEqual(result, expected)
 
   def test_with_break_before_skip(self) -> None:
     chunks = ['abc', 'def', 'ghi', 'jkl']
     html = "abc<button>defghi</button>jkl"
     result = html_processor.resolve(chunks, html)
-    expected = '<span style="word-break: keep-all; overflow-wrap: anywhere;">abc<wbr><button>defghi</button><wbr>jkl</span>'
+    expected = '<span style="word-break: keep-all; overflow-wrap: anywhere;">abc\u200b<button>defghi</button>\u200bjkl</span>'
     self.assertEqual(result, expected)
 
   def test_with_nothing_to_split(self) -> None:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -130,7 +130,7 @@ class TestTextArguments(unittest.TestCase):
 
     self.assertEqual(
         output, '<span style="word-break: keep-all; overflow-wrap: anywhere;">'
-        '今日は<b><wbr>とても<wbr>天気</b>です。</span>')
+        '今日は<b>\u200bとても\u200b天気</b>です。</span>')
 
   def test_cmdargs_multi_html(self) -> None:
     cmdargs = ['-H', '今日は<b>とても天気</b>です。', 'これは<b>テスト</b>です。']
@@ -172,7 +172,7 @@ class TestStdin(unittest.TestCase):
 
     self.assertEqual(
         output, '<span style="word-break: keep-all; overflow-wrap: anywhere;">'
-        'これは<b><wbr>テスト</b>です。<wbr>\n'
+        'これは<b>\u200bテスト</b>です。\u200b\n'
         '</span>')
 
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -62,7 +62,7 @@ class TestParser(unittest.TestCase):
     input_html = 'xyzabcd'
     expected_html = (
         '<span style="word-break: keep-all; overflow-wrap: anywhere;">'
-        'xyz<wbr>abcd</span>')
+        'xyz\u200babcd</span>')
     output_html = p.translate_html_string(input_html)
     self.assertEqual(
         output_html, expected_html,
@@ -75,7 +75,7 @@ class TestParser(unittest.TestCase):
     # content" and "skip breaking" in future.
     expected_html = (
         '<span style="word-break: keep-all; overflow-wrap: anywhere;">'
-        'xyz<wbr><script>alert(1);</script>xyz<wbr>abc</span>')
+        'xyz\u200b<script>alert(1);</script>xyz\u200babc</span>')
     output_html = p.translate_html_string(input_html)
     self.assertEqual(output_html, expected_html,
                      'Should pass script tags as is.')
@@ -83,7 +83,7 @@ class TestParser(unittest.TestCase):
     input_html = 'xyz<code>abc</code>abc'
     expected_html = (
         '<span style="word-break: keep-all; overflow-wrap: anywhere;">'
-        'xyz<wbr><code>abc</code><wbr>abc</span>')
+        'xyz\u200b<code>abc</code>\u200babc</span>')
     output_html = p.translate_html_string(input_html)
     self.assertEqual(output_html, expected_html,
                      'Should skip some specific tags.')
@@ -91,7 +91,7 @@ class TestParser(unittest.TestCase):
     input_html = 'xyza<a href="#" hidden>bc</a>abc'
     expected_html = (
         '<span style="word-break: keep-all; overflow-wrap: anywhere;">'
-        'xyz<wbr>a<a href="#" hidden>bc</a><wbr>abc</span>')
+        'xyz\u200ba<a href="#" hidden>bc</a>\u200babc</span>')
     output_html = p.translate_html_string(input_html)
     self.assertEqual(output_html, expected_html,
                      'Should not ruin attributes of child elements.')
@@ -99,7 +99,7 @@ class TestParser(unittest.TestCase):
     input_html = 'xyza🇯🇵🇵🇹abc'
     expected_html = (
         '<span style="word-break: keep-all; overflow-wrap: anywhere;">'
-        'xyz<wbr>a🇯🇵🇵🇹<wbr>abc</span>')
+        'xyz\u200ba🇯🇵🇵🇹\u200babc</span>')
     output_html = p.translate_html_string(input_html)
     self.assertEqual(output_html, expected_html, 'Should work with emojis.')
 


### PR DESCRIPTION
This changes the default separator from WBR to ZWSP.

We observed that some screen readers split their text focus by chunks because of the inserted WBR elements. We also considered adding the `aria-hidden="true"` attribute to the WBR elements as a workaround, but the behavior was still not ideal and stable. On the other hand, the ZWSP approach does not split the text focus and works better because it does not alter the DOM tree structure. Considering that, I suggest to use ZWSP as the default separator for accessibility improvement.

Users can still use WBR tags if it's preferred by specifying the separator element.

```typescript
import {jaModel, HTMLProcessingParser} from 'budoux';
const parser = HTMLProcessingParser(jaModel, {separator: document.createElement('wbr')});
```