### PR TITLE
Rename applyElement to applyToElement

### DIFF
--- a/demo/src/app.ts
+++ b/demo/src/app.ts
@@ -54,7 +54,7 @@ const run = () => {
   worker.postMessage({'sentence': outputContainerElement.textContent, 'model': model});
   const parser = parsers.get(model);
   if (!parser) return;
-  parser.applyElement(outputContainerElement);
+  parser.applyToElement(outputContainerElement);
   outputContainerElement.style.fontSize = `${fontSizeElement.value}rem`;
   const renderWithBR = brCheckElement.checked;
   if (renderWithBR) {

--- a/javascript/README.md
+++ b/javascript/README.md
@@ -67,12 +67,12 @@ You can also feed an HTML element to the parser to apply the process.
 const ele = document.querySelector('p.budou-this');
 console.log(ele.outerHTML);
 // <p class="budou-this">今日は<b>とても天気</b>です。</p>
-parser.applyElement(ele);
+parser.applyToElement(ele);
 console.log(ele.outerHTML);
 // <p class="budou-this" style="word-break: keep-all; overflow-wrap: anywhere;">今日は<b><wbr>とても<wbr>天気</b>です。</p>
 ```
 
-Internally, the `applyElement` calls the [`HTMLProcessor`] class
+Internally, the `applyToElement` calls the [`HTMLProcessor`] class
 with a `<wbr>` element as the separator.
 You can use the [`HTMLProcessor`] class directly if desired.
 For example:

--- a/javascript/src/html_processor.ts
+++ b/javascript/src/html_processor.ts
@@ -603,10 +603,25 @@ export class HTMLProcessingParser extends Parser {
   }
 
   /**
+   * @deprecated Use `applyToElement` instead. `applyElement` will be removed
+   * in v0.7.0 to align the function name with `HTMLProcessor`'s API.
+   *
    * Applies markups for semantic line breaks to the given HTML element.
    * @param parentElement The input element.
    */
   applyElement(parentElement: HTMLElement) {
+    console.warn(
+      '`applyElement` is deprecated. Please use `applyToElement` instead. ' +
+        '`applyElement` will be removed in v0.7.0.'
+    );
+    this.applyToElement(parentElement);
+  }
+
+  /**
+   * Applies markups for semantic line breaks to the given HTML element.
+   * @param parentElement The input element.
+   */
+  applyToElement(parentElement: HTMLElement) {
     this.htmlProcessor.applyToElement(parentElement);
   }
 
@@ -624,7 +639,7 @@ export class HTMLProcessingParser extends Parser {
       wrapper.append(...doc.body.childNodes);
       doc.body.append(wrapper);
     }
-    this.applyElement(doc.body.childNodes[0] as HTMLElement);
+    this.applyToElement(doc.body.childNodes[0] as HTMLElement);
     return doc.body.innerHTML;
   }
 }

--- a/javascript/src/tests/test_html_processor.ts
+++ b/javascript/src/tests/test_html_processor.ts
@@ -316,7 +316,7 @@ describe('HTMLProcessor.splitNodes', () => {
   });
 });
 
-describe('HTMLProcessingParser.applyElement', () => {
+describe('HTMLProcessingParser.applyToElement', () => {
   const checkEqual = (
     model: {[key: string]: {[key: string]: number}},
     inputHTML: string,
@@ -325,7 +325,7 @@ describe('HTMLProcessingParser.applyElement', () => {
     const inputDOM = parseFromString(inputHTML);
     const inputDocument = inputDOM.querySelector('p') as HTMLElement;
     const parser = new HTMLProcessingParser(model);
-    parser.applyElement(inputDocument);
+    parser.applyToElement(inputDocument);
     const expectedDocument = parseFromString(expectedHTML);
     const expectedElement = expectedDocument.querySelector('p') as HTMLElement;
     expect(inputDocument.isEqualNode(expectedElement)).toBeTrue();

--- a/javascript/src/tests/test_webcomponents.ts
+++ b/javascript/src/tests/test_webcomponents.ts
@@ -33,7 +33,7 @@ describe('Web Components', () => {
 
     const mirroredElement = window.document.createElement('span');
     mirroredElement.textContent = inputText;
-    parser.applyElement(mirroredElement);
+    parser.applyToElement(mirroredElement);
 
     expect(budouxElement.innerHTML).toBe(mirroredElement.outerHTML);
   });
@@ -46,7 +46,7 @@ describe('Web Components', () => {
     const inputText = '明日はどうなるかな。';
     const mirroredElement = window.document.createElement('span');
     mirroredElement.textContent = inputText;
-    parser.applyElement(mirroredElement);
+    parser.applyToElement(mirroredElement);
 
     const observer = new window.MutationObserver(() => {
       expect(budouxElement.innerHTML).toBe(mirroredElement.outerHTML);


### PR DESCRIPTION
Rename `applyElement` to `applyToElement` to make it align with `HTMLProcessor`'s API and avoid confusion. (It will apply the change **to** the element, but not apply the element to something else.)