### PR TITLE
Fix unpaired close tags and self-closing tags

### DIFF
--- a/budoux/html_processor.py
+++ b/budoux/html_processor.py
@@ -36,6 +36,7 @@ class ElementState(object):
     tag (str): The tag name.
     to_skip (bool): Whether the content should be skipped or not.
   """
+
   def __init__(self, tag: str, to_skip: bool) -> None:
     self.tag = tag
     self.to_skip = to_skip

--- a/tests/test_html_processor.py
+++ b/tests/test_html_processor.py
@@ -76,7 +76,7 @@ class TestHTMLChunkResolver(unittest.TestCase):
     resolver = html_processor.HTMLChunkResolver(['abxyabc', 'def'], '<wbr>')
     resolver.feed(input)
     self.assertEqual(resolver.output, expected,
-                     'WBR tags should not be inserted if NOBR.')
+                     'IMG should not affect surrounding NOBR.')
 
 
 class TestResolve(unittest.TestCase):

--- a/tests/test_html_processor.py
+++ b/tests/test_html_processor.py
@@ -46,6 +46,38 @@ class TestHTMLChunkResolver(unittest.TestCase):
     self.assertEqual(resolver.output, expected,
                      'WBR tags should be inserted as specified by chunks.')
 
+  def test_unpaired(self) -> None:
+    input = '<p>abcdef</p></p>'
+    expected = '<p>abc<wbr>def</p></p>'
+    resolver = html_processor.HTMLChunkResolver(['abc', 'def'], '<wbr>')
+    resolver.feed(input)
+    self.assertEqual(resolver.output, expected,
+                     'Unpaired close tag should not cause errors.')
+
+  def test_nobr(self) -> None:
+    input = '<p>ab<nobr>cde</nobr>f</p>'
+    expected = '<p>ab<nobr>cde</nobr>f</p>'
+    resolver = html_processor.HTMLChunkResolver(['abc', 'def'], '<wbr>')
+    resolver.feed(input)
+    self.assertEqual(resolver.output, expected,
+                     'WBR tags should not be inserted if in NOBR.')
+
+  def test_after_nobr(self) -> None:
+    input = '<p>ab<nobr>xy</nobr>abcdef</p>'
+    expected = '<p>ab<nobr>xy</nobr>abc<wbr>def</p>'
+    resolver = html_processor.HTMLChunkResolver(['abxyabc', 'def'], '<wbr>')
+    resolver.feed(input)
+    self.assertEqual(resolver.output, expected,
+                     'WBR tags should be inserted if after NOBR.')
+
+  def test_img_in_nobr(self) -> None:
+    input = '<p>ab<nobr>x<img>y</nobr>abcdef</p>'
+    expected = '<p>ab<nobr>x<img>y</nobr>abc<wbr>def</p>'
+    resolver = html_processor.HTMLChunkResolver(['abxyabc', 'def'], '<wbr>')
+    resolver.feed(input)
+    self.assertEqual(resolver.output, expected,
+                     'WBR tags should not be inserted if NOBR.')
+
 
 class TestResolve(unittest.TestCase):
 


### PR DESCRIPTION
https://github.com/google/budoux/pull/251 assumed that all tags are closed properly.

This assumption doesn't stand for cases like:
1. Self-closing tags such as `<img>` don't have corresponding close tags.
2. Unpaired close tags are still valid HTML.

This patch supports these cases by assuming all open tags that doesn't nest correctly or that doesn't close are automatically closed.

This isn't the full HTML "adoption agency algorithm", but it should be good enough for the needs of BudouX.

Fixes #355