### PR TITLE
[Java] Stop emitting close tags if self-closing

### DIFF
--- a/.github/workflows/style-check.yml
+++ b/.github/workflows/style-check.yml
@@ -71,7 +71,8 @@ jobs:
           args: "--replace"
           skip-commit: true
       - name: Print diffs
-        run: git --no-pager diff --exit-code  markdown-style-check:
+        run: git --no-pager diff --exit-code
+  markdown-style-check:
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner

--- a/.github/workflows/style-check.yml
+++ b/.github/workflows/style-check.yml
@@ -69,7 +69,7 @@ jobs:
         uses: axel-op/googlejavaformat-action@fe78db8a90171b6a836449f8d0e982d5d71e5c5a
         with:
           args: "--replace"
-          skip-commit: true
+          skipCommit: true
       - name: Print diffs
         run: git --no-pager diff --exit-code
   markdown-style-check:

--- a/.github/workflows/style-check.yml
+++ b/.github/workflows/style-check.yml
@@ -68,8 +68,10 @@ jobs:
       - name: Google Java Format
         uses: axel-op/googlejavaformat-action@fe78db8a90171b6a836449f8d0e982d5d71e5c5a
         with:
-          args: "--dry-run --set-exit-if-changed"
-  markdown-style-check:
+          args: "--replace"
+          skip-commit: true
+      - name: Print diffs
+        run: git --no-pager diff --exit-code  markdown-style-check:
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner

--- a/.github/workflows/style-check.yml
+++ b/.github/workflows/style-check.yml
@@ -66,10 +66,10 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
       - name: Google Java Format
-        uses: axel-op/googlejavaformat-action@fe78db8a90171b6a836449f8d0e982d5d71e5c5a
+        uses: axel-op/googlejavaformat-action@v3
         with:
           args: "--replace"
-          skipCommit: true
+          skip-commit: true
       - name: Print diffs
         run: git --no-pager diff --exit-code
   markdown-style-check:

--- a/.github/workflows/style-check.yml
+++ b/.github/workflows/style-check.yml
@@ -66,12 +66,9 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
       - name: Google Java Format
-        uses: axel-op/googlejavaformat-action@v3
+        uses: axel-op/googlejavaformat-action@fe78db8a90171b6a836449f8d0e982d5d71e5c5a
         with:
-          args: "--replace"
-          skip-commit: true
-      - name: Print diffs
-        run: git --no-pager diff --exit-code
+          args: "--dry-run --set-exit-if-changed"
   markdown-style-check:
     runs-on: ubuntu-latest
     steps:

--- a/java/src/main/java/com/google/budoux/HTMLProcessor.java
+++ b/java/src/main/java/com/google/budoux/HTMLProcessor.java
@@ -128,7 +128,7 @@ final class HTMLProcessor {
       }
       // assume node instanceof Element;
       toSkip = elementStack.pop();
-      Element element = (Element)node;
+      Element element = (Element) node;
       if (element.tag().isSelfClosing()) {
         return;
       }

--- a/java/src/main/java/com/google/budoux/HTMLProcessor.java
+++ b/java/src/main/java/com/google/budoux/HTMLProcessor.java
@@ -128,6 +128,10 @@ final class HTMLProcessor {
       }
       // assume node instanceof Element;
       toSkip = elementStack.pop();
+      Element element = (Element)node;
+      if (element.tag().isSelfClosing()) {
+        return;
+      }
       output.append(String.format("</%s>", node.nodeName()));
     }
   }

--- a/java/src/test/java/com/google/budoux/HTMLProcessorTest.java
+++ b/java/src/test/java/com/google/budoux/HTMLProcessorTest.java
@@ -47,9 +47,7 @@ public class HTMLProcessorTest {
     List<String> phrases = Arrays.asList("abc", "def");
     String html = "ab<a href=\"http://example.com\">cd</a>ef";
     String result = HTMLProcessor.resolve(phrases, html, "<wbr>");
-    assertEquals(
-        this.wrap("ab<a href=\"http://example.com\">c<wbr>d</a>ef"),
-        result);
+    assertEquals(this.wrap("ab<a href=\"http://example.com\">c<wbr>d</a>ef"), result);
   }
 
   @Test
@@ -89,9 +87,7 @@ public class HTMLProcessorTest {
     List<String> phrases = Arrays.asList("abc", "def", "ghi", "jkl");
     String html = "abc<nobr>def</nobr>ghijkl";
     String result = HTMLProcessor.resolve(phrases, html, "<wbr>");
-    assertEquals(
-        this.wrap("abc<wbr><nobr>def</nobr><wbr>ghi<wbr>jkl"),
-        result);
+    assertEquals(this.wrap("abc<wbr><nobr>def</nobr><wbr>ghi<wbr>jkl"), result);
   }
 
   @Test
@@ -99,9 +95,7 @@ public class HTMLProcessorTest {
     List<String> phrases = Arrays.asList("abc", "def", "ghi", "jkl");
     String html = "abc<nobr>d<img>ef</nobr>ghijkl";
     String result = HTMLProcessor.resolve(phrases, html, "<wbr>");
-    assertEquals(
-        this.wrap("abc<wbr><nobr>d<img>ef</nobr><wbr>ghi<wbr>jkl"),
-        result);
+    assertEquals(this.wrap("abc<wbr><nobr>d<img>ef</nobr><wbr>ghi<wbr>jkl"), result);
   }
 
   @Test

--- a/java/src/test/java/com/google/budoux/HTMLProcessorTest.java
+++ b/java/src/test/java/com/google/budoux/HTMLProcessorTest.java
@@ -27,15 +27,19 @@ import org.junit.runners.JUnit4;
 /** Unit tests for {@link HTMLProcessor}. */
 @RunWith(JUnit4.class)
 public class HTMLProcessorTest {
+  String pre = "<span style=\"word-break: keep-all; overflow-wrap: anywhere;\">";
+  String post = "</span>";
+
+  private String wrap(String input) {
+    return this.pre + input + this.post;
+  }
 
   @Test
   public void testResolveWithSimpleTextInput() {
     List<String> phrases = Arrays.asList("abc", "def");
     String html = "abcdef";
     String result = HTMLProcessor.resolve(phrases, html, "<wbr>");
-    assertEquals(
-        "<span style=\"word-break: keep-all; overflow-wrap: anywhere;\">abc<wbr>def</span>",
-        result);
+    assertEquals(this.wrap("abc<wbr>def"), result);
   }
 
   @Test
@@ -44,9 +48,24 @@ public class HTMLProcessorTest {
     String html = "ab<a href=\"http://example.com\">cd</a>ef";
     String result = HTMLProcessor.resolve(phrases, html, "<wbr>");
     assertEquals(
-        "<span style=\"word-break: keep-all; overflow-wrap: anywhere;\">ab<a"
-            + " href=\"http://example.com\">c<wbr>d</a>ef</span>",
+        this.wrap("ab<a href=\"http://example.com\">c<wbr>d</a>ef"),
         result);
+  }
+
+  @Test
+  public void testResolveWithImg() {
+    List<String> phrases = Arrays.asList("abc", "def");
+    String html = "<img>abcdef";
+    String result = HTMLProcessor.resolve(phrases, html, "<wbr>");
+    assertEquals(this.wrap("<img>abc<wbr>def"), result);
+  }
+
+  @Test
+  public void testResolveWithUnpairedClose() {
+    List<String> phrases = Arrays.asList("abc", "def");
+    String html = "abcdef</p>";
+    String result = HTMLProcessor.resolve(phrases, html, "<wbr>");
+    assertEquals(this.wrap("abc<wbr>def<p></p>"), result);
   }
 
   @Test
@@ -54,10 +73,7 @@ public class HTMLProcessorTest {
     List<String> phrases = Arrays.asList("abc", "def", "ghi");
     String html = "a<button>bcde</button>fghi";
     String result = HTMLProcessor.resolve(phrases, html, "<wbr>");
-    assertEquals(
-        "<span style=\"word-break: keep-all; overflow-wrap:"
-            + " anywhere;\">a<button>bcde</button>f<wbr>ghi</span>",
-        result);
+    assertEquals(this.wrap("a<button>bcde</button>f<wbr>ghi"), result);
   }
 
   @Test
@@ -65,9 +81,26 @@ public class HTMLProcessorTest {
     List<String> phrases = Arrays.asList("abc", "def", "ghi", "jkl");
     String html = "abc<nobr>defghi</nobr>jkl";
     String result = HTMLProcessor.resolve(phrases, html, "<wbr>");
+    assertEquals(this.wrap("abc<wbr><nobr>defghi</nobr><wbr>jkl"), result);
+  }
+
+  @Test
+  public void testResolveWithAfterSkip() {
+    List<String> phrases = Arrays.asList("abc", "def", "ghi", "jkl");
+    String html = "abc<nobr>def</nobr>ghijkl";
+    String result = HTMLProcessor.resolve(phrases, html, "<wbr>");
     assertEquals(
-        "<span style=\"word-break: keep-all; overflow-wrap:"
-            + " anywhere;\">abc<wbr><nobr>defghi</nobr><wbr>jkl</span>",
+        this.wrap("abc<wbr><nobr>def</nobr><wbr>ghi<wbr>jkl"),
+        result);
+  }
+
+  @Test
+  public void testResolveWithAfterSkipWithImg() {
+    List<String> phrases = Arrays.asList("abc", "def", "ghi", "jkl");
+    String html = "abc<nobr>d<img>ef</nobr>ghijkl";
+    String result = HTMLProcessor.resolve(phrases, html, "<wbr>");
+    assertEquals(
+        this.wrap("abc<wbr><nobr>d<img>ef</nobr><wbr>ghi<wbr>jkl"),
         result);
   }
 
@@ -76,8 +109,7 @@ public class HTMLProcessorTest {
     List<String> phrases = Arrays.asList("abcdef");
     String html = "abcdef";
     String result = HTMLProcessor.resolve(phrases, html, "<wbr>");
-    assertEquals(
-        "<span style=\"word-break: keep-all; overflow-wrap: anywhere;\">abcdef</span>", result);
+    assertEquals(this.wrap("abcdef"), result);
   }
 
   @Test


### PR DESCRIPTION
This patch changes Java `HTMLProcessor` not to emit close tags if the tag is self-closing.

Also adds tests for:
* Unpaired close tags.
* Self-closing tags don't affect skip nodes (e.g., `<nobr>`.)

These test cases are from #355.

Fixes #361.