### PR TITLE
Rename @returns to @return

### DIFF
--- a/javascript/src/cli.ts
+++ b/javascript/src/cli.ts
@@ -129,7 +129,7 @@ const outputParsedTexts = (
 
 /**
  * Loads a parser equipped with custom model.
- * @returns A parser with the loaded model.
+ * @return A parser with the loaded model.
  */
 const loadCustomParser = (modelPath: string) => {
   const file = readFileSync(path.resolve(modelPath)).toString();

--- a/javascript/src/dom.ts
+++ b/javascript/src/dom.ts
@@ -24,7 +24,7 @@ import {win} from './win.js';
 /**
  * Parses an html string and returns a parsed html document.
  * @param html An HTML string.
- * @returns A Document.
+ * @return A Document.
  */
 export const parseFromString = (html: string) => {
   return new win.DOMParser().parseFromString(html, 'text/html');

--- a/javascript/src/html_processor.ts
+++ b/javascript/src/html_processor.ts
@@ -166,7 +166,7 @@ const NODETYPE = {
 /**
  * Determine the action for an element.
  * @param element An element to determine the action for.
- * @returns The {@link domActions} for the element.
+ * @return The {@link domActions} for the element.
  */
 function actionForElement(element: Element): DomAction {
   const nodeName = element.nodeName;
@@ -292,7 +292,7 @@ class Paragraph {
   }
 
   /**
-   * @returns Indices of forced break opportunities in the source.
+   * @return Indices of forced break opportunities in the source.
    * They can be created by `<wbr>` tag or `&ZeroWidthSpace;`.
    */
   getForcedOpportunities(): number[] {
@@ -318,7 +318,7 @@ class Paragraph {
   }
 
   /**
-   * @returns Filtered {@param boundaries} by excluding
+   * @return Filtered {@param boundaries} by excluding
    * {@link getForcedOpportunities} if it's not empty.
    * Otherwise {@param boundaries}.
    */
@@ -378,7 +378,7 @@ export class HTMLProcessor {
    * Checks if the given element has a text node in its children.
    *
    * @param ele An element to be checked.
-   * @returns Whether the element has a child text node.
+   * @return Whether the element has a child text node.
    */
   static hasChildTextNode(ele: HTMLElement) {
     for (const child of ele.childNodes) {
@@ -405,7 +405,7 @@ export class HTMLProcessor {
    * Find paragraphs from a given HTML element.
    * @param element The root element to find paragraphs.
    * @param parent The parent {@link Paragraph} if any.
-   * @returns A list of {@link Paragraph}s.
+   * @return A list of {@link Paragraph}s.
    */
   *getBlocks(
     element: HTMLElement,
@@ -629,7 +629,7 @@ export class HTMLProcessingParser extends Parser {
    * Translates the given HTML string to another HTML string with markups
    * for semantic line breaks.
    * @param html An input html string.
-   * @returns The translated HTML string.
+   * @return The translated HTML string.
    */
   translateHTMLString(html: string) {
     if (html === '') return html;

--- a/javascript/src/index.ts
+++ b/javascript/src/index.ts
@@ -25,7 +25,7 @@ export {jaModel, zhHansModel, zhHantModel};
 
 /**
  * Loads a parser equipped with the default Japanese model.
- * @returns A parser with the default Japanese model.
+ * @return A parser with the default Japanese model.
  */
 export const loadDefaultJapaneseParser = () => {
   return new HTMLProcessingParser(jaModel);
@@ -33,7 +33,7 @@ export const loadDefaultJapaneseParser = () => {
 
 /**
  * Loads a parser equipped with the default Simplified Chinese model.
- * @returns A parser with the default Simplified Chinese model.
+ * @return A parser with the default Simplified Chinese model.
  */
 export const loadDefaultSimplifiedChineseParser = () => {
   return new HTMLProcessingParser(zhHansModel);
@@ -41,7 +41,7 @@ export const loadDefaultSimplifiedChineseParser = () => {
 
 /**
  * Loads a parser equipped with the default Traditional Chinese model.
- * @returns A parser with the default Traditional Chinese model.
+ * @return A parser with the default Traditional Chinese model.
  */
 export const loadDefaultTraditionalChineseParser = () => {
   return new HTMLProcessingParser(zhHantModel);
@@ -49,7 +49,7 @@ export const loadDefaultTraditionalChineseParser = () => {
 
 /**
  * Loads available default parsers.
- * @returns A map between available lang codes and their default parsers.
+ * @return A map between available lang codes and their default parsers.
  */
 export const loadDefaultParsers = () => {
   return new Map([

--- a/javascript/src/parser.ts
+++ b/javascript/src/parser.ts
@@ -35,7 +35,7 @@ export class Parser {
    * Parses the input sentence and returns a list of semantic chunks.
    *
    * @param sentence An input sentence.
-   * @returns The retrieved chunks.
+   * @return The retrieved chunks.
    */
   parse(sentence: string): string[] {
     if (sentence === '') return [];
@@ -54,7 +54,7 @@ export class Parser {
    * Parses the input sentence and returns a list of boundaries.
    *
    * @param sentence An input sentence.
-   * @returns The list of boundaries.
+   * @return The list of boundaries.
    */
   parseBoundaries(sentence: string): number[] {
     const result = [];


### PR DESCRIPTION
Use `@return` instead of `@returns` to align with [Google TypeScript Style Guide](https://google.github.io/styleguide/tsguide.html)