### PR TITLE
Add granularity option to prepare_knbc.py

### DIFF
--- a/scripts/prepare_knbc.py
+++ b/scripts/prepare_knbc.py
@@ -81,10 +81,9 @@ class KNBCHTMLParser(HTMLParser):
     if tag == 'td':
       self.col += 1
       for name, value in attributes:
-        if (name == 'id' and
-            value == self.BUNSETSU_SPLIT_ID) or (self.granularity == 'tag' and
-                                                 name == 'id' and
-                                                 value == self.TAG_SPLIT_ID):
+        bunsetsu_row = name == 'id' and value == self.BUNSETSU_SPLIT_ID
+        tag_row = name == 'id' and value == self.TAG_SPLIT_ID
+        if bunsetsu_row or (self.granularity == 'tag' and tag_row):
           self.on_split_row = True
 
   def handle_endtag(self, tag: str) -> None:

--- a/scripts/tests/test_prepare_knbc.py
+++ b/scripts/tests/test_prepare_knbc.py
@@ -61,12 +61,17 @@ class TestKNBCHTMLParser(unittest.TestCase):
   </html>
   '''
 
-  def test_parse(self) -> None:
-    parser = prepare_knbc.KNBCHTMLParser(False)
+  def test_parse_phrase(self) -> None:
+    parser = prepare_knbc.KNBCHTMLParser('phrase')
     parser.feed(self.example_html)
     self.assertListEqual(parser.chunks, ['abcdefghijkl', 'mn'])
 
-  def test_parse_split_tags(self) -> None:
-    parser = prepare_knbc.KNBCHTMLParser(True)
+  def test_parse_tag(self) -> None:
+    parser = prepare_knbc.KNBCHTMLParser('tag')
     parser.feed(self.example_html)
     self.assertListEqual(parser.chunks, ['abcde', 'fghijkl', 'mn'])
+
+  def test_parse_word(self) -> None:
+    parser = prepare_knbc.KNBCHTMLParser('word')
+    parser.feed(self.example_html)
+    self.assertListEqual(parser.chunks, ['abc', 'de', 'fgh', 'ijkl', 'mn'])


### PR DESCRIPTION
Now users can control the granularity of chunks to be generated from the KNBC corpus with the `granularity` arg.

```bash
python scripts/prepare_knbc.py KNBC_v1.0_090925_utf8 --granularity=phrase
python scripts/prepare_knbc.py KNBC_v1.0_090925_utf8 --granularity=tag
python scripts/prepare_knbc.py KNBC_v1.0_090925_utf8 --granularity=word
```