### PR TITLE
Replace pkg_resources with importlib_resources

### DIFF
--- a/.github/workflows/py-unittest.yml
+++ b/.github/workflows/py-unittest.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.8, 3.9, '3.10']
+        python-version: [3.8, 3.9, '3.10', 3.11, 3.12]
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1

--- a/budoux/main.py
+++ b/budoux/main.py
@@ -27,7 +27,7 @@ import importlib_resources
 import budoux
 
 ArgList = typing.Optional[typing.List[str]]
-models: Path = importlib_resources.files('budoux') / "models"  # type: ignore
+models: Path = importlib_resources.files('budoux') / "models"
 langs = dict((model.stem, model) for model in models.glob("*.json"))
 
 

--- a/budoux/main.py
+++ b/budoux/main.py
@@ -22,6 +22,7 @@ import textwrap
 import typing
 from pathlib import Path
 
+# TODO: replace with importlib.resources when py3.8 support is dropped.
 import importlib_resources
 
 import budoux

--- a/budoux/main.py
+++ b/budoux/main.py
@@ -15,18 +15,20 @@
 """BudouX Script to provide CLI for user."""
 import argparse
 import glob
+import importlib.resources
 import json
 import os
 import shutil
 import sys
 import textwrap
 import typing
-
-import pkg_resources
+from pathlib import Path
 
 import budoux
 
 ArgList = typing.Optional[typing.List[str]]
+models: Path = importlib.resources.files('budoux') / "models"  # type: ignore
+langs = dict((model.stem, model) for model in models.glob("*.json"))
 
 
 class BudouxHelpFormatter(argparse.ArgumentDefaultsHelpFormatter,
@@ -52,22 +54,7 @@ def check_file(path: str) -> str:
     raise argparse.ArgumentTypeError(f"'{path}' is not found.")
 
 
-def get_model_langs() -> typing.Dict[str, str]:
-  """Get a dictionary of model languages and its paths.
-
-  Returns:
-      typing.Dict[str, str]: A dictionary of model languages and its paths.
-  """
-  models = glob.glob(
-      pkg_resources.resource_filename(__name__, "models") + "/*.json")
-  langs = {}
-  for model in models:
-    lang = model.split(os.sep)[-1][:-5]
-    langs[lang] = model
-  return langs
-
-
-def check_lang(lang: str) -> str:
+def check_lang(lang: str) -> Path:
   """Check if given language exists or not.
 
   Args:
@@ -77,9 +64,8 @@ def check_lang(lang: str) -> str:
       argparse.ArgumentTypeError: Raise if no model for given language exists.
 
   Returns:
-      str: A model path.
+      The model path.
   """
-  langs = get_model_langs()
   if lang in langs:
     return langs[lang]
   else:
@@ -110,8 +96,7 @@ def parse_args(test: ArgList = None) -> argparse.Namespace:
         BudouX is the successor to Budou,
         the machine learning powered line break organizer tool."""),
       epilog="\n- ".join(
-          ["supported languages of `-l`, `--lang`:",
-           *get_model_langs().keys()]))
+          ["supported languages of `-l`, `--lang`:", *langs.keys()]))
 
   parser.add_argument("text", metavar="TXT", nargs="?", type=str, help="text")
   parser.add_argument(
@@ -126,7 +111,7 @@ def parse_args(test: ArgList = None) -> argparse.Namespace:
       "--model",
       metavar="JSON",
       type=check_file,
-      default=pkg_resources.resource_filename(__name__, "models/ja.json"),
+      default=check_lang('ja'),
       help="custom model file path",
   )
   model_select_group.add_argument(

--- a/budoux/main.py
+++ b/budoux/main.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 """BudouX Script to provide CLI for user."""
 import argparse
-import glob
-import importlib.resources
 import json
 import os
 import shutil
@@ -24,10 +22,12 @@ import textwrap
 import typing
 from pathlib import Path
 
+import importlib_resources
+
 import budoux
 
 ArgList = typing.Optional[typing.List[str]]
-models: Path = importlib.resources.files('budoux') / "models"  # type: ignore
+models: Path = importlib_resources.files('budoux') / "models"  # type: ignore
 langs = dict((model.stem, model) for model in models.glob("*.json"))
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,6 +14,8 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
 
 [options]
 python_requires= >= 3.8

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,8 @@ python_requires= >= 3.8
 packages = find:
 include_package_data = True
 test_suite = tests
+install_requires =
+    importlib-resources
 
 [options.extras_require]
 dev =


### PR DESCRIPTION
Context: https://setuptools.pypa.io/en/latest/pkg_resources.html

> Use of pkg_resources is deprecated in favor of [importlib.resources](https://docs.python.org/3.11/library/importlib.resources.html#module-importlib.resources), [importlib.metadata](https://docs.python.org/3.11/library/importlib.metadata.html#module-importlib.metadata) and their backports ([importlib_resources](https://pypi.org/project/importlib_resources), [importlib_metadata](https://pypi.org/project/importlib_metadata)). Some useful APIs are also provided by [packaging](https://pypi.org/project/packaging) (e.g. requirements and version parsing). Users should refrain from new usage of pkg_resources and should work to port to importlib-based solutions.