### PR TITLE
Mention Korean support in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,16 @@ Last but not least, BudouX supports HTML inputs.
 
 <https://google.github.io/budoux>
 
-## Natural languages supported by default
+## Natural languages supported by pretrained models
 
 - Japanese
 - Simplified Chinese
 - Traditional Chinese
 - Thai
+
+### Korean support?
+Korean uses spaces between words, so you can generally prevent words from being split across lines by applying the CSS property `word-break: keep-all` to the paragraph, which should be much performant than installing BudouX.
+That said, we're happy to explore dedicated Korean language support if the above solution proves insufficient.
 
 ## Supported Programming languages
 


### PR DESCRIPTION
Due to frequent inquiries about Korean language support, we're adding a description of the tentative solution using `word-break: keep-all`.