### PR TITLE
[Java] Handle comment nodes

### DIFF
--- a/java/src/main/java/com/google/budoux/HTMLProcessor.java
+++ b/java/src/main/java/com/google/budoux/HTMLProcessor.java
@@ -32,6 +32,7 @@ import java.util.Locale;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.jsoup.Jsoup;
+import org.jsoup.nodes.Comment;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.nodes.Node;
@@ -156,7 +157,7 @@ final class HTMLProcessor {
 
     @Override
     public void tail(Node node, int depth) {
-      if (node.nodeName().equals("body") || node instanceof TextNode) {
+      if (node.nodeName().equals("body") || node instanceof TextNode || node instanceof Comment) {
         return;
       }
       // assume node instanceof Element;

--- a/java/src/test/java/com/google/budoux/HTMLProcessorTest.java
+++ b/java/src/test/java/com/google/budoux/HTMLProcessorTest.java
@@ -136,4 +136,12 @@ public class HTMLProcessorTest {
     String result = HTMLProcessor.getText(html);
     assertEquals(" 1  2 ", result);
   }
+
+  @Test
+  public void testResolveWithComments() {
+    List<String> phrases = Arrays.asList("abc", "def", "ghi", "jkl");
+    String html = "abcdef<!-- comments should be ignored-->ghijkl";
+    String result = HTMLProcessor.resolve(phrases, html, "<wbr>");
+    assertEquals(this.wrap("abc<wbr>def<wbr>ghi<wbr>jkl"), result);
+  }
 }


### PR DESCRIPTION
Current Java code does not work with HTML strings that have comment nodes, throwing the following error.

```
java.util.NoSuchElementException
        at java.base/java.util.ArrayDeque.removeFirst(ArrayDeque.java:363)
        at java.base/java.util.ArrayDeque.pop(ArrayDeque.java:594)
        at com.google.budoux.HTMLProcessor$PhraseResolvingNodeVisitor.tail(HTMLProcessor.java:163)
        at org.jsoup.select.NodeTraversor.traverse(NodeTraversor.java:59)
        at org.jsoup.nodes.Node.traverse(Node.java:707)
        at org.jsoup.nodes.Element.traverse(Element.java:1883)
        at com.google.budoux.HTMLProcessor.resolve(HTMLProcessor.java:194)
```

This PR fixes this issue by ignoring comment nodes in the node visitor.