### PR TITLE
[Java] Skip node at the end of input

### DIFF
--- a/java/src/main/java/com/google/budoux/HTMLProcessor.java
+++ b/java/src/main/java/com/google/budoux/HTMLProcessor.java
@@ -130,7 +130,9 @@ final class HTMLProcessor {
           // Assume phrasesJoined.charAt(scanIndex) == '\n'.
           scanIndex++;
         } else if (skipNodes.contains(nodeName.toUpperCase(Locale.ENGLISH))) {
-          if (!toSkip && scanIndex < phrasesJoined.length() && phrasesJoined.charAt(scanIndex) == SEP) {
+          if (!toSkip
+              && scanIndex < phrasesJoined.length()
+              && phrasesJoined.charAt(scanIndex) == SEP) {
             output.append(separator);
             scanIndex++;
           }

--- a/java/src/main/java/com/google/budoux/HTMLProcessor.java
+++ b/java/src/main/java/com/google/budoux/HTMLProcessor.java
@@ -130,7 +130,7 @@ final class HTMLProcessor {
           // Assume phrasesJoined.charAt(scanIndex) == '\n'.
           scanIndex++;
         } else if (skipNodes.contains(nodeName.toUpperCase(Locale.ENGLISH))) {
-          if (!toSkip && phrasesJoined.charAt(scanIndex) == SEP) {
+          if (!toSkip && scanIndex < phrasesJoined.length() && phrasesJoined.charAt(scanIndex) == SEP) {
             output.append(separator);
             scanIndex++;
           }

--- a/java/src/test/java/com/google/budoux/HTMLProcessorTest.java
+++ b/java/src/test/java/com/google/budoux/HTMLProcessorTest.java
@@ -136,4 +136,12 @@ public class HTMLProcessorTest {
     String result = HTMLProcessor.getText(html);
     assertEquals(" 1  2 ", result);
   }
+
+  @Test
+  public void testResolveSkipNodeAtTheEnd() {
+    List<String> phrases = Arrays.asList("abc", "def", "ghi", "jkl");
+    String html = "abcdefghijkl<img src=\"example.png\">";
+    String result = HTMLProcessor.resolve(phrases, html, "<wbr>");
+    assertEquals(this.wrap("abc<wbr>def<wbr>ghi<wbr>jkl<img src=\"example.png\">"), result);
+  }
 }


### PR DESCRIPTION
Current Java code throws the following error when the input HTML has a skip node at the end. This PR fixes the issue.

```
java.lang.StringIndexOutOfBoundsException: index 15,length 15
        at java.base/java.lang.String.checkIndex(String.java:3278)
        at java.base/java.lang.StringUTF16.checkIndex(StringUTF16.java:1470)
        at java.base/java.lang.StringUTF16.charAt(StringUTF16.java:1267)
        at java.base/java.lang.String.charAt(String.java:695)
        at com.google.budoux.HTMLProcessor$PhraseResolvingNodeVisitor.head(HTMLProcessor.java:133)
        at org.jsoup.select.NodeTraversor.traverse(NodeTraversor.java:34)
        at org.jsoup.nodes.Node.traverse(Node.java:707)
        at org.jsoup.nodes.Element.traverse(Element.java:1883)
        at com.google.budoux.HTMLProcessor.resolve(HTMLProcessor.java:194)
```