### PR TITLE
Remove org.sonatype.oss parent from pom.xml

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -18,18 +18,33 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <parent>
-    <groupId>org.sonatype.oss</groupId>
-    <artifactId>oss-parent</artifactId>
-    <version>7</version>
-  </parent>
-
   <groupId>com.google.budoux</groupId>
   <artifactId>budoux</artifactId>
   <version>0.6.3</version>
 
   <name>BudouX</name>
   <url>https://google.github.io/budoux/</url>
+  <description>Tiny phrase segmenter</description>
+  <licenses>
+    <license>
+      <name>The Apache License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
+  <developers>
+    <developer>
+      <organization>Google</organization>
+      <organizationUrl>http://www.google.com</organizationUrl>
+    </developer>
+  </developers>
+
+  <scm>
+    <connection>scm:git:git@github.com:google/budoux.git</connection>
+    <developerConnection>scm:git:git@github.com:google/budoux.git</developerConnection>
+    <url>git@github.com:google/budoux.git</url>
+  </scm>
+
+  <packaging>pom</packaging>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -94,6 +109,32 @@
           <version>3.13.0</version>
         </plugin>
         <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-source-plugin</artifactId>
+          <version>2.4</version>
+          <executions>
+            <execution>
+              <id>attach-sources</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+            </execution>
+          </executions>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-javadoc-plugin</artifactId>
+          <version>2.10.3</version>
+          <executions>
+            <execution>
+              <id>attach-javadocs</id>
+              <goals>
+                <goal>jar</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+        <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
           <version>3.5.1</version>
         </plugin>
@@ -109,6 +150,20 @@
           <artifactId>maven-deploy-plugin</artifactId>
           <version>3.1.3</version>
         </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-gpg-plugin</artifactId>
+          <version>1.6</version>
+          <executions>
+            <execution>
+              <id>sign-artifacts</id>
+              <phase>verify</phase>
+              <goals>
+                <goal>sign</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
         <!-- site lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#site_Lifecycle -->
         <plugin>
           <artifactId>maven-site-plugin</artifactId>
@@ -120,5 +175,24 @@
         </plugin>
       </plugins>
     </pluginManagement>
+    <!-- The parent needs to be signed. -->
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-gpg-plugin</artifactId>
+      </plugin>
+    </plugins>
   </build>
+  <distributionManagement>
+    <repository>
+      <id>sonatype-nexus-staging</id>
+      <name>Sonatype Nexus Staging</name>
+      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
+    </repository>
+    <snapshotRepository>
+      <id>sonatype-nexus-snapshots</id>
+      <name>Sonatype Nexus Snapshots</name>
+      <url>http://oss.sonatype.org/content/repositories/snapshots</url>
+    </snapshotRepository>
+  </distributionManagement>
 </project>


### PR DESCRIPTION
`org.sonatype.oss` depends on the old version of `maven-javadoc-plugin`, which raises the following error in deployment.

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:2.7:jar (attach-javadocs) on project budoux:
Execution attach-javadocs of goal org.apache.maven.plugins:maven-javadoc-plugin:2.7:jar
failed: Unable to load the mojo 'jar' in the plugin 'org.apache.maven.plugins:maven-javadoc-plugin:2.7' due to an API incompatibility: org.codehaus.plexus.component.repository.exception.ComponentLookupException: null 
```

This change removes the dependency to `org.sonatype.oss` and updates the `pom.xml` to use the updated `maven-javadoc-plugin`.