### PR TITLE
Use updated maven-javadoc-plugin

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.sonatype.oss</groupId>
     <artifactId>oss-parent</artifactId>
-    <version>7</version>
+    <version>9</version>
   </parent>
 
   <groupId>com.google.budoux</groupId>
@@ -56,6 +56,13 @@
   </dependencies>
 
   <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>3.10.0</version>
+      </plugin>
+    </plugins>
     <pluginManagement><!-- lock down plugins versions to avoid using Maven defaults (may be moved to parent pom) -->
       <plugins>
         <!-- clean lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#clean_Lifecycle -->

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -26,7 +26,7 @@
 
   <groupId>com.google.budoux</groupId>
   <artifactId>budoux</artifactId>
-  <version>0.6.3</version>
+  <version>0.6.4</version>
 
   <name>BudouX</name>
   <url>https://google.github.io/budoux/</url>


### PR DESCRIPTION
Force update maven-javadoc-plugin to resolve the error mentioned in #773 
We keep using the same parent pom.xml for now to minimize the gap between the past artifacts.
It also updates the Java port version to override the misconfigured v0.6.3 release.