### PR TITLE
Deploy demo site directly with GitHub Actions

### DIFF
--- a/.github/workflows/build-demo.yml
+++ b/.github/workflows/build-demo.yml
@@ -4,29 +4,30 @@ permissions:
   contents: read
 
 jobs:
-  deploy:
-    permissions:
-      contents: write  # for peaceiris/actions-gh-pages to push pages branch
+  build:
     runs-on: ubuntu-latest
     steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@0080882f6c36860b6ba35c610c98ce87d4e2f26f # v2.10.2
-        with:
-          egress-policy: audit
-
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
-        with:
-          node-version: '16'
       - run: npm install
         working-directory: ./javascript
       - run: npm install
         working-directory: ./demo
       - run: npm run build
         working-directory: ./demo
-      - name: Publish Demo
-        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e
-        if: ${{ github.ref == 'refs/heads/main' }}
+      - name: Upload static files as artifact
+        id: deployment
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./demo/static
+          path: ./demo/static/
+  deploy:
+    needs: build
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5


### PR DESCRIPTION
Deploy the demo site directly using GitHub Actions
ref. https://github.blog/changelog/2022-07-27-github-pages-custom-github-actions-workflows-beta/