### PR TITLE
Add type guards for NodeOrText

### DIFF
--- a/javascript/src/html_processor.ts
+++ b/javascript/src/html_processor.ts
@@ -243,6 +243,7 @@ class NodeOrText {
       ? this.nodeOrText
       : this.nodeOrText.nodeValue;
   }
+
   get length(): number {
     return this.text?.length ?? 0;
   }
@@ -255,9 +256,7 @@ class NodeOrText {
     const chunks = this.chunks;
     assert(chunks.length === 0 || chunks.join('') === this.text);
     if (chunks.length <= 1) return;
-    if (this.isString(this.nodeOrText)) {
-      return;
-    }
+    if (this.isString(this.nodeOrText)) return;
     const node = this.nodeOrText;
     if (typeof separator === 'string') {
       // If the `separator` is a string, insert it at each boundary.

--- a/javascript/src/html_processor.ts
+++ b/javascript/src/html_processor.ts
@@ -230,16 +230,16 @@ class NodeOrText {
     this.nodeOrText = nodeOrText;
   }
 
-  private isString(value: Text | string): value is string {
-    return typeof this.nodeOrText === 'string';
+  private static isString(value: Text | string): value is string {
+    return typeof value  =='string';
   }
 
   get canSplit(): boolean {
-    return !this.isString(this.nodeOrText);
+    return !NodeOrText.isString(this.nodeOrText);
   }
 
   get text(): string | null {
-    return this.isString(this.nodeOrText)
+    return NodeOrText.isString(this.nodeOrText)
       ? this.nodeOrText
       : this.nodeOrText.nodeValue;
   }
@@ -256,7 +256,7 @@ class NodeOrText {
     const chunks = this.chunks;
     assert(chunks.length === 0 || chunks.join('') === this.text);
     if (chunks.length <= 1) return;
-    if (this.isString(this.nodeOrText)) return;
+    if (NodeOrText.isString(this.nodeOrText)) return;
     const node = this.nodeOrText;
     if (typeof separator === 'string') {
       // If the `separator` is a string, insert it at each boundary.

--- a/javascript/src/html_processor.ts
+++ b/javascript/src/html_processor.ts
@@ -231,7 +231,7 @@ class NodeOrText {
   }
 
   private static isString(value: Text | string): value is string {
-    return typeof value  =='string';
+    return typeof value === 'string';
   }
 
   get canSplit(): boolean {

--- a/javascript/src/html_processor.ts
+++ b/javascript/src/html_processor.ts
@@ -230,16 +230,18 @@ class NodeOrText {
     this.nodeOrText = nodeOrText;
   }
 
-  get isString(): boolean {
+  private isString(value: Text | string): value is string {
     return typeof this.nodeOrText === 'string';
   }
+
   get canSplit(): boolean {
-    return !this.isString;
+    return !this.isString(this.nodeOrText);
   }
+
   get text(): string | null {
-    return this.isString
-      ? (this.nodeOrText as string)
-      : (this.nodeOrText as Text).nodeValue;
+    return this.isString(this.nodeOrText)
+      ? this.nodeOrText
+      : this.nodeOrText.nodeValue;
   }
   get length(): number {
     return this.text?.length ?? 0;
@@ -253,8 +255,10 @@ class NodeOrText {
     const chunks = this.chunks;
     assert(chunks.length === 0 || chunks.join('') === this.text);
     if (chunks.length <= 1) return;
-    assert(this.canSplit);
-    const node = this.nodeOrText as Text;
+    if (this.isString(this.nodeOrText)) {
+      return;
+    }
+    const node = this.nodeOrText;
     if (typeof separator === 'string') {
       // If the `separator` is a string, insert it at each boundary.
       node.nodeValue = chunks.join(separator);


### PR DESCRIPTION
Use user-defined type guards to handle Node vs string in a more IDE-friendly way.