### PR TITLE
Add notes on Web Components

### DIFF
--- a/javascript/README.md
+++ b/javascript/README.md
@@ -177,7 +177,19 @@ import 'budoux/module/webcomponents/budoux-zh-hant';
 import 'budoux/module/webcomponents/budoux-th';
 ```
 
-**Note:** BudouX Web Components directly manipulate the input HTML content instead of outputting the result to a shadow DOM. This design was chosen because the goal of BudouX Web Components is to simply insert zero-width spaces (ZWSPs) into the content, and isolating the style from the rest of the document could introduce unexpected side effects for developers. Consequently, cloning or editing the component might lead to duplicated ZWSPs between phrases. This is because BudouX Web Components cannot distinguish between characters that originate in the source and those that are inserted by BudouX itself once connected to the document. Duplicating ZWSPs will not cause any severe problems in controlling line breaks, and they are invisible anyway, but this is the reason we do not support other separator characters for these components.
+**Note:** BudouX Web Components directly manipulate the input HTML content
+instead of outputting the result to a shadow DOM. This design was chosen because
+the goal of BudouX Web Components is to simply insert zero-width spaces (ZWSPs)
+into the content, and isolating the style from the rest of the document could
+introduce unexpected side effects for developers.
+
+Consequently, cloning or editing the element might lead to duplicated ZWSPs
+between phrases. This is because BudouX Web Components cannot distinguish
+between characters that originate in the source and those that are inserted by
+BudouX itself once connected to the document. Duplicating ZWSPs will not cause
+any severe problems in controlling line breaks, and they are invisible anyway,
+but this is the reason we do not support other separator characters for these
+components.
 
 ### CLI
 

--- a/javascript/README.md
+++ b/javascript/README.md
@@ -177,6 +177,8 @@ import 'budoux/module/webcomponents/budoux-zh-hant';
 import 'budoux/module/webcomponents/budoux-th';
 ```
 
+**Note:** BudouX Web Components directly manipulate the input HTML content instead of outputting the result to a shadow DOM. This design was chosen because the goal of BudouX Web Components is to simply insert zero-width spaces (ZWSPs) into the content, and isolating the style from the rest of the document could introduce unexpected side effects for developers. Consequently, cloning or editing the component might lead to duplicated ZWSPs between phrases. This is because BudouX Web Components cannot distinguish between characters that originate in the source and those that are inserted by BudouX itself once connected to the document. Duplicating ZWSPs will not cause any severe problems in controlling line breaks, and they are invisible anyway, but this is the reason we do not support other separator characters for these components.
+
 ### CLI
 
 You can also format inputs on your terminal with `budoux` command.


### PR DESCRIPTION
Adding a note which explains that Web Components may introduce duplicated ZWSPs and why it should not be a problem.