### PR TITLE
Fix python typing issue

### DIFF
--- a/scripts/finetune.py
+++ b/scripts/finetune.py
@@ -27,7 +27,7 @@ from collections import OrderedDict
 from jax import Array, grad, jit
 from jax import numpy as jnp
 
-EPSILON: float = jnp.finfo(float).eps
+EPSILON = float(jnp.finfo(float).eps)
 DEFAULT_OUTPUT_NAME = 'finetuned-weights.txt'
 DEFAULT_NUM_ITERS = 1000
 DEFAULT_LOG_SPAN = 100

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -23,7 +23,7 @@ from typing import NamedTuple
 import jax
 import jax.numpy as jnp
 
-EPS: float = jnp.finfo(float).eps
+EPS = float(jnp.finfo(float).eps)
 DEFAULT_OUTPUT_NAME = 'weights.txt'
 DEFAULT_LOG_NAME = 'train.log'
 DEFAULT_FEATURE_THRES = 10


### PR DESCRIPTION
The latest mypy and jax combination yields the typing error as below. This fixes the issue by making it sure that the epsilon is a float.

```
scripts/train.py:26: error: Incompatible types in assignment (expression has
type "floating[Any]", variable has type "float")  [assignment]
    EPS: float = jnp.finfo(float).eps
                 ^~~~~~~~~~~~~~~~~~~~
scripts/finetune.py:30: error: Incompatible types in assignment (expression has
type "floating[Any]", variable has type "float")  [assignment]
    EPSILON: float = jnp.finfo(float).eps
                     ^~~~~~~~~~~~~~~~~~~~
Found 2 errors in 2 files (checked 23 source files)
```