### PR TITLE
Add exports in package.json

### DIFF
--- a/javascript/package.json
+++ b/javascript/package.json
@@ -2,6 +2,8 @@
   "name": "budoux",
   "version": "0.6.3",
   "description": "A small chunk segmenter.",
+  "author": "Shuhei Iitsuka",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/google/budoux.git",
@@ -9,6 +11,16 @@
   },
   "main": "./dist/index.js",
   "module": "./module/index.js",
+  "exports": {
+    ".": {
+      "import": "./module/index.js",
+      "require": "./dist/index.js"
+    }
+  },
+  "browser": {
+    "./dist/win.js": "./dist/win-browser.js",
+    "./module/win.js": "./module/win-browser.js"
+  },
   "bin": {
     "budoux": "./bin/budoux.js"
   },
@@ -17,9 +29,9 @@
     "./module/tests/*"
   ],
   "scripts": {
-    "build": "npm run build:es && npm run build:cjs",
+    "build": "npm run build:esm && npm run build:cjs",
     "build:cjs": "tsc && cp -r src/tests/models/ dist/tests/models/",
-    "build:es": "tsc --outDir module --module ES2020 && cp module/win-browser.js module/win.js && cp -r src/tests/models/ module/tests/models/",
+    "build:esm": "tsc --outDir module --module ES2020 && cp -r src/tests/models/ module/tests/models/",
     "bundle": "npm run bundle:webcomponents && npm run bundle:test",
     "bundle:test": "esbuild module/tests/index.browser.js --bundle --sourcemap --outfile=bundle/tests/index.browser.js",
     "bundle:webcomponents": "npm run bundle:webcomponents:ja && npm run bundle:webcomponents:zh-hans && npm run bundle:webcomponents:zh-hant && npm run bundle:webcomponents:th",
@@ -38,12 +50,6 @@
     "test:karma": "karma start",
     "lint": "eslint src/** --no-error-on-unmatched-pattern",
     "fix": "eslint src/** --no-error-on-unmatched-pattern --fix"
-  },
-  "author": "Shuhei Iitsuka",
-  "license": "Apache-2.0",
-  "browser": {
-    "./dist/win.js": "./dist/win-browser.js",
-    "./module/win.js": "./module/win-browser.js"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.1.0",


### PR DESCRIPTION
This PR improves the package distribution of Budoux to enhance compatibility and usability in various JavaScript environments.

Specifically, it addresses the following:

*   **Node.js ESM Support:** Previously, the build process for ESM would incorrectly overwrite `win.ts` with `win-browser.ts`. This prevented Node.js environments from using the ESM build, as `win-browser.ts` relies on browser-specific APIs. This change ensures that Node.js can properly import and use the ESM version of Budoux.
*   **Enhanced Package Resolution with `exports` Field:** The addition of the `exports` field in `package.json` provides explicit mappings for different module formats (CommonJS and ESM). This improves interoperability with modern JavaScript bundlers and frameworks, ensuring they correctly resolve the appropriate module format and avoid potential conflicts. This also simplifies usage for developers by providing clear entry points.
