### PR TITLE
Isolate functions only used by tests

### DIFF
--- a/javascript/package.json
+++ b/javascript/package.json
@@ -19,7 +19,9 @@
   },
   "browser": {
     "./dist/dom.js": "./dist/dom-browser.js",
-    "./module/dom.js": "./module/dom-browser.js"
+    "./module/dom.js": "./module/dom-browser.js",
+    "./dist/tests/testutils.js": "./dist/tests/testutils-browser.js",
+    "./module/tests/testutils.js": "./module/tests/testutils-browser.js"
   },
   "bin": {
     "budoux": "./bin/budoux.js"

--- a/javascript/src/dom.ts
+++ b/javascript/src/dom.ts
@@ -14,12 +14,7 @@
  * limitations under the License.
  */
 
-/**
- * This file is a collection of risky functions that interact with elements.
- * BudouX does not apply any HTML sanitization by default, but this is the place
- * to install a sanitizer if needed.
- */
-import {DOMParser, parseHTML} from 'linkedom';
+import {DOMParser} from 'linkedom';
 
 /**
  * Parses an html string and returns a parsed html document.
@@ -32,26 +27,3 @@ export const parseFromString = (html: string) => {
     'text/html'
   );
 };
-
-/**
- * Sets an innerHTML on a given Element or ShadowRoot.
- * @param element An Element or ShadowRoot.
- * @param html An HTML string to set.
- */
-export const setInnerHtml = (element: Element | ShadowRoot, html: string) => {
-  element.innerHTML = html;
-};
-
-/**
- * Creates an HTML document.
- * @returns Document
- */
-export const createDocument = () => {
-  const {document} = parseHTML('<!doctype html><html></html>');
-  return document;
-};
-
-/**
- * Whether the running environment is a Web browser.
- */
-export const isBrowser = false;

--- a/javascript/src/tests/test_html_processor.ts
+++ b/javascript/src/tests/test_html_processor.ts
@@ -22,12 +22,8 @@ import {
   NodeOrTextForTesting,
   ParagraphForTesting,
 } from '../html_processor.js';
-import {
-  parseFromString,
-  setInnerHtml,
-  createDocument,
-  isBrowser,
-} from '../dom.js';
+import {parseFromString} from '../dom.js';
+import {setInnerHtml, createDocument, isBrowser} from './testutils.js';
 
 const parser = loadDefaultJapaneseParser();
 

--- a/javascript/src/tests/testutils-browser.ts
+++ b/javascript/src/tests/testutils-browser.ts
@@ -15,11 +15,11 @@
  */
 
 /**
- * Sets an innerHTML on a given Element or ShadowRoot.
- * @param element An Element or ShadowRoot.
+ * Sets an innerHTML on a given Element.
+ * @param element An Element.
  * @param html An HTML string to set.
  */
-export const setInnerHtml = (element: Element | ShadowRoot, html: string) => {
+export const setInnerHtml = (element: Element, html: string) => {
   element.innerHTML = html;
 };
 

--- a/javascript/src/tests/testutils-browser.ts
+++ b/javascript/src/tests/testutils-browser.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2021 Google LLC
+ * Copyright 2025 Google LLC
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -15,10 +15,23 @@
  */
 
 /**
- * Parses an html string and returns a parsed html document.
- * @param html An HTML string.
- * @return A Document.
+ * Sets an innerHTML on a given Element or ShadowRoot.
+ * @param element An Element or ShadowRoot.
+ * @param html An HTML string to set.
  */
-export const parseFromString = (html: string) => {
-  return new window.DOMParser().parseFromString(html, 'text/html');
+export const setInnerHtml = (element: Element | ShadowRoot, html: string) => {
+  element.innerHTML = html;
 };
+
+/**
+ * Creates an HTML document.
+ * @returns Document
+ */
+export const createDocument = () => {
+  return window.document;
+};
+
+/**
+ * Whether the running environment is a Web browser.
+ */
+export const isBrowser = true;

--- a/javascript/src/tests/testutils.ts
+++ b/javascript/src/tests/testutils.ts
@@ -17,11 +17,11 @@
 import {parseHTML} from 'linkedom';
 
 /**
- * Sets an innerHTML on a given Element or ShadowRoot.
- * @param element An Element or ShadowRoot.
+ * Sets an innerHTML on a given Element.
+ * @param element An Element.
  * @param html An HTML string to set.
  */
-export const setInnerHtml = (element: Element | ShadowRoot, html: string) => {
+export const setInnerHtml = (element: Element, html: string) => {
   element.innerHTML = html;
 };
 

--- a/javascript/src/tests/testutils.ts
+++ b/javascript/src/tests/testutils.ts
@@ -1,0 +1,40 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {parseHTML} from 'linkedom';
+
+/**
+ * Sets an innerHTML on a given Element or ShadowRoot.
+ * @param element An Element or ShadowRoot.
+ * @param html An HTML string to set.
+ */
+export const setInnerHtml = (element: Element | ShadowRoot, html: string) => {
+  element.innerHTML = html;
+};
+
+/**
+ * Creates an HTML document.
+ * @returns Document
+ */
+export const createDocument = () => {
+  const {document} = parseHTML('<!doctype html><html></html>');
+  return document;
+};
+
+/**
+ * Whether the running environment is a Web browser.
+ */
+export const isBrowser = false;


### PR DESCRIPTION
Isolate DOM related functions used only by tests into `testutils.ts`, making the original `dom.ts` and `dom-browser.ts` as small as possible. By doing this, the product code don't need to worry about risky functions such as `setInnerHTML`.