### PR TITLE
🧹 Fix typo 'quivalent' in train.py

### DIFF
--- a/scripts/train.py
+++ b/scripts/train.py
@@ -212,7 +212,7 @@ def update(w: jax.Array, scores: jax.Array, rows: jax.Array, cols: jax.Array,
   """
   N = w.shape[0]
   M = scores.shape[0]
-  # This is quivalent to w.dot(Y[:, None] ^ X). Note that y ^ x = y + x - 2yx,
+  # This is equivalent to w.dot(Y[:, None] ^ X). Note that y ^ x = y + x - 2yx,
   # hence w.dot(y ^ x) = w.dot(y) - w(2y - 1).dot(x).
   # `segment_sum` is used to implement sparse matrix-friendly dot products.
   res = w.dot(Y) - jax.ops.segment_sum((w * (2 * Y - 1)).take(rows), cols, M)


### PR DESCRIPTION
🎯 **What:** Fixed a typo in a comment in `scripts/train.py` where 'quivalent' was written instead of 'equivalent'.
💡 **Why:** Correcting typos improves the maintainability and readability of the codebase.
✅ **Verification:** Verified by manual inspection and `grep` search. Ran existing tests using `pytest` and they passed.
✨ **Result:** The typo is corrected, making the code's documentation clearer.

---
*PR created automatically by Jules for task [16996538399949074909](https://jules.google.com/task/16996538399949074909) started by @tushuhei*