### PR TITLE
Bump to 0.8.2

### DIFF
--- a/budoux/__init__.py
+++ b/budoux/__init__.py
@@ -15,7 +15,7 @@
 
 from . import parser
 
-__version__ = "0.8.1"
+__version__ = "0.8.2"
 
 Parser = parser.Parser
 load_default_japanese_parser = parser.load_default_japanese_parser

--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -21,7 +21,7 @@
     },
     "../javascript": {
       "name": "budoux",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "license": "Apache-2.0",
       "dependencies": {
         "commander": "^14.0.0",

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -20,7 +20,7 @@
 
   <groupId>com.google.budoux</groupId>
   <artifactId>budoux</artifactId>
-  <version>0.8.1</version>
+  <version>0.8.2</version>
 
   <name>BudouX</name>
   <description>BudouX: A standalone, small, and language-neutral segmenter library</description>

--- a/javascript/package-lock.json
+++ b/javascript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "budoux",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "budoux",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "license": "Apache-2.0",
       "dependencies": {
         "commander": "^14.0.0",

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "budoux",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "A small chunk segmenter.",
   "author": "Shuhei Iitsuka",
   "license": "Apache-2.0",

--- a/javascript/src/cli.ts
+++ b/javascript/src/cli.ts
@@ -24,7 +24,7 @@ import {
   loadDefaultParsers,
 } from './index.js';
 
-const CLI_VERSION = '0.8.1';
+const CLI_VERSION = '0.8.2';
 const defaultParsers = loadDefaultParsers();
 
 /**


### PR DESCRIPTION
Bumped the version to 0.8.2 across Python, JavaScript, and Java implementations. Verified with tests and refreshed lock files.

---
*PR created automatically by Jules for task [2251323595336826371](https://jules.google.com/task/2251323595336826371) started by @tushuhei*