### PR TITLE
Consolidate JS version management

### DIFF
--- a/.github/workflows/style-check.yml
+++ b/.github/workflows/style-check.yml
@@ -70,7 +70,6 @@ jobs:
         with:
           args: "--replace"
           skip-commit: true
-          github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Print diffs
         run: git --no-pager diff --exit-code
   markdown-style-check:

--- a/.github/workflows/style-check.yml
+++ b/.github/workflows/style-check.yml
@@ -70,6 +70,7 @@ jobs:
         with:
           args: "--replace"
           skip-commit: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Print diffs
         run: git --no-pager diff --exit-code
   markdown-style-check:

--- a/bump_version.py
+++ b/bump_version.py
@@ -46,14 +46,6 @@ def main():
   else:
     print(f"JavaScript version is already {new_version}, skipping npm version.")
 
-  cli_file = 'javascript/src/cli.ts'
-  with open(cli_file, 'r') as f:
-    content = f.read()
-  new_content = re.sub(r'(const\s+CLI_VERSION\s+=\s+[\'"])([\.\-\w]+)([\'"])',
-                       rf'\g<1>{new_version}\g<3>', content)
-  with open(cli_file, 'w') as f:
-    f.write(new_content)
-
   # Updates Java port version number
   mvn_command = [
       'mvn', 'versions:set', f'-DnewVersion={new_version}',

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -79,7 +79,7 @@
   "scripts": {
     "build": "npm run build:esm && npm run build:cjs",
     "build:cjs": "tsc && cp -r src/tests/models/ dist/tests/models/",
-    "build:esm": "tsc --outDir module --module ES2020 && cp -r src/tests/models/ module/tests/models/ && node -e \"require('fs').writeFileSync('module/package.json', '{\\\"type\\\":\\\"module\\\"}')\"",
+    "build:esm": "tsc --outDir module --module ES2020 && cp -r src/tests/models/ module/tests/models/ && node -e \"require('fs').writeFileSync('module/package.json', '{\\\"type\\\":\\\"module\\\"}')\" && node -e \"const fs = require('fs'); const f = 'module/cli.js'; fs.writeFileSync(f, fs.readFileSync(f, 'utf8').replace(/path\\.resolve\\(__dirname, ['\\\"]\\.\\.\\/package\\.json['\\\"]\\)/g, 'new URL(\\\"../package.json\\\", import.meta.url)'))\"",
     "bundle": "npm run bundle:webcomponents",
     "bundle:webcomponents": "npm run bundle:webcomponents:ja && npm run bundle:webcomponents:zh-hans && npm run bundle:webcomponents:zh-hant && npm run bundle:webcomponents:th",
     "bundle:webcomponents:ja": "esbuild module/webcomponents/budoux-ja.js --bundle --minify --sourcemap --outfile=bundle/budoux-ja.min.js",

--- a/javascript/src/cli.ts
+++ b/javascript/src/cli.ts
@@ -24,7 +24,10 @@ import {
   loadDefaultParsers,
 } from './index.js';
 
-const CLI_VERSION = '0.8.1';
+const packageJson = JSON.parse(
+  readFileSync(path.resolve(__dirname, '../package.json'), 'utf8')
+);
+const CLI_VERSION = packageJson.version;
 const defaultParsers = loadDefaultParsers();
 
 /**

--- a/javascript/src/tests/test_cli.ts
+++ b/javascript/src/tests/test_cli.ts
@@ -233,4 +233,16 @@ describe('cli', () => {
 
     expect(stderr).toBe("error: unknown option '-v'\n");
   });
+
+  it('should output the version number when execute budoux command with -V option.', async () => {
+    const {stdout} = await runCli(['-V']);
+    const packageJson = require('../../package.json');
+    expect(stdout.trim()).toBe(packageJson.version);
+  });
+
+  it('should output the version number when execute budoux command with --version option.', async () => {
+    const {stdout} = await runCli(['--version']);
+    const packageJson = require('../../package.json');
+    expect(stdout.trim()).toBe(packageJson.version);
+  });
 });


### PR DESCRIPTION
Consolidated the JavaScript version management into `package.json` as requested. The CLI now reads the version at runtime. I've also updated the build process to handle the transition from CommonJS to ESM correctly for this runtime version check, and updated the `bump_version.py` script to reflect these changes.

---
*PR created automatically by Jules for task [17675792431317670526](https://jules.google.com/task/17675792431317670526) started by @tushuhei*