### PR TITLE
fix(java): skip ZWSP insertion at start of block elements

### DIFF
--- a/java/src/main/java/com/google/budoux/HTMLProcessor.java
+++ b/java/src/main/java/com/google/budoux/HTMLProcessor.java
@@ -145,12 +145,16 @@ final class HTMLProcessor {
         Node parent = node.parentNode();
         boolean isFirstChild = parent != null && parent.childNode(0) == node;
         boolean isInBlock = parent instanceof Element && ((Element) parent).isBlock();
+        boolean isWhitespaceOnly = data.trim().isEmpty();
+        boolean isListParent = parent != null && (parent.nodeName().equalsIgnoreCase("ul") || parent.nodeName().equalsIgnoreCase("ol"));
         for (int i = 0; i < data.length(); i++) {
           char c = data.charAt(i);
           if (c != phrasesJoined.charAt(scanIndex)) {
             // Assume phrasesJoined.charAt(scanIndex) == SEP.
             if (!toSkip) {
-              if (i > 0 || !isFirstChild || !isInBlock) {
+              boolean skipIntro = i == 0 && isFirstChild && isInBlock;
+              boolean skipListWhitespace = isWhitespaceOnly && isListParent;
+              if (!skipIntro && !skipListWhitespace) {
                 output.append(separator);
               }
             }

--- a/java/src/main/java/com/google/budoux/HTMLProcessor.java
+++ b/java/src/main/java/com/google/budoux/HTMLProcessor.java
@@ -142,12 +142,17 @@ final class HTMLProcessor {
         output.append(String.format("<%s%s>", nodeName, attributesEncoded));
       } else if (node instanceof TextNode) {
         String data = ((TextNode) node).getWholeText();
+        Node parent = node.parentNode();
+        boolean isFirstChild = parent != null && parent.childNode(0) == node;
+        boolean isInBlock = parent instanceof Element && ((Element) parent).isBlock();
         for (int i = 0; i < data.length(); i++) {
           char c = data.charAt(i);
           if (c != phrasesJoined.charAt(scanIndex)) {
             // Assume phrasesJoined.charAt(scanIndex) == SEP.
             if (!toSkip) {
-              output.append(separator);
+              if (i > 0 || !isFirstChild || !isInBlock) {
+                output.append(separator);
+              }
             }
             scanIndex++;
           }

--- a/java/src/test/java/com/google/budoux/HTMLProcessorTest.java
+++ b/java/src/test/java/com/google/budoux/HTMLProcessorTest.java
@@ -168,4 +168,11 @@ public class HTMLProcessorTest {
     String result = HTMLProcessor.resolve(phrases, html, "<wbr>");
     assertEquals(this.wrap("<ul><li>あ</li><li>い</li></ul>"), result);
   }
+  @Test
+  public void testResolveWithListItemsAndWhitespace() {
+    List<String> phrases = Arrays.asList("あ", "\nい");
+    String html = "<ul><li>あ</li>\n<li>い</li></ul>";
+    String result = HTMLProcessor.resolve(phrases, html, "<wbr>");
+    assertEquals(this.wrap("<ul><li>あ</li>\n<li>い</li></ul>"), result);
+  }
 }

--- a/java/src/test/java/com/google/budoux/HTMLProcessorTest.java
+++ b/java/src/test/java/com/google/budoux/HTMLProcessorTest.java
@@ -152,4 +152,20 @@ public class HTMLProcessorTest {
     String result = HTMLProcessor.resolve(phrases, html, "<wbr>");
     assertEquals(this.wrap("abc<wbr>def<wbr>ghi<wbr>jkl"), result);
   }
+
+  @Test
+  public void testResolveWithSpanBoundaries() {
+    List<String> phrases = Arrays.asList("あ", "い");
+    String html = "<span>あ</span><span>い</span>";
+    String result = HTMLProcessor.resolve(phrases, html, "<wbr>");
+    assertEquals(this.wrap("<span>あ</span><span><wbr>い</span>"), result);
+  }
+
+  @Test
+  public void testResolveWithListItems() {
+    List<String> phrases = Arrays.asList("あ", "い");
+    String html = "<ul><li>あ</li><li>い</li></ul>";
+    String result = HTMLProcessor.resolve(phrases, html, "<wbr>");
+    assertEquals(this.wrap("<ul><li>あ</li><li>い</li></ul>"), result);
+  }
 }


### PR DESCRIPTION
This PR addresses the issue where BudouX incorrectly inserts zero-width spaces (ZWSP) or other separators at the beginning of text nodes within block elements (e.g., `<li>`), even when it corresponds to a semantic boundary where breaking is natural or already handled by the block display.

### Changes
- In `HTMLProcessor.java`, skip inserting the separator if it coincides with the start of a text node that is the first child of a block element.
- Added tests to verify this behavior for list items, while preserving the existing behavior for inline elements (`<span>`).
