### PR TITLE
Fix: Avoid inserting separator before whitespace in HTMLProcessor.

### DIFF
--- a/budoux/html_processor.py
+++ b/budoux/html_processor.py
@@ -109,7 +109,7 @@ class HTMLChunkResolver(HTMLParser):
   def handle_data(self, data: str) -> None:
     for char in data:
       if not char == self.chunks_joined[self.scan_index]:
-        if not self.to_skip:
+        if not self.to_skip and not char.isspace():
           self.output += self.separator
         self.scan_index += 1
       self.output += char

--- a/java/src/main/java/com/google/budoux/HTMLProcessor.java
+++ b/java/src/main/java/com/google/budoux/HTMLProcessor.java
@@ -146,7 +146,7 @@ final class HTMLProcessor {
           char c = data.charAt(i);
           if (c != phrasesJoined.charAt(scanIndex)) {
             // Assume phrasesJoined.charAt(scanIndex) == SEP.
-            if (!toSkip) {
+            if (!toSkip && !Character.isWhitespace(c)) {
               output.append(separator);
             }
             scanIndex++;

--- a/java/src/test/java/com/google/budoux/HTMLProcessorTest.java
+++ b/java/src/test/java/com/google/budoux/HTMLProcessorTest.java
@@ -152,4 +152,12 @@ public class HTMLProcessorTest {
     String result = HTMLProcessor.resolve(phrases, html, "<wbr>");
     assertEquals(this.wrap("abc<wbr>def<wbr>ghi<wbr>jkl"), result);
   }
+
+  @Test
+  public void testResolveWithListItemsAndWhitespace() {
+    List<String> phrases = Arrays.asList("abc", "\ndef");
+    String html = "<ul><li>abc</li>\n<li>def</li></ul>";
+    String result = HTMLProcessor.resolve(phrases, html, "<wbr>");
+    assertEquals(this.wrap("<ul><li>abc</li>\n<li>def</li></ul>"), result);
+  }
 }

--- a/tests/test_html_processor.py
+++ b/tests/test_html_processor.py
@@ -115,3 +115,10 @@ class TestResolve(unittest.TestCase):
     result = html_processor.resolve(chunks, html)
     expected = '<span style="word-break: keep-all; overflow-wrap: anywhere;">abcdef</span>'
     self.assertEqual(result, expected)
+
+  def test_with_list_items_and_whitespace(self) -> None:
+    chunks = ['abc', '\ndef']
+    html = '<ul><li>abc</li>\n<li>def</li></ul>'
+    result = html_processor.resolve(chunks, html, '<wbr>')
+    expected = '<span style="word-break: keep-all; overflow-wrap: anywhere;"><ul><li>abc</li>\n<li>def</li></ul></span>'
+    self.assertEqual(result, expected)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -172,7 +172,7 @@ class TestStdin(unittest.TestCase):
 
     self.assertEqual(
         output, '<span style="word-break: keep-all; overflow-wrap: anywhere;">'
-        'これは<b>\u200bテスト</b>です。\u200b\n'
+        'これは<b>\u200bテスト</b>です。\n'
         '</span>')
 
 


### PR DESCRIPTION
This fixes an issue where BudouX Java and Python may insert a separator between a closed LI tag and an open LI tag due to whitespace between them, causing layout issues.