### PR TITLE
feat: align Python and Java HTMLProcessor with JS port behavior

### DIFF
--- a/budoux/html_processor.py
+++ b/budoux/html_processor.py
@@ -48,19 +48,28 @@ class TextContentExtractor(HTMLParser):
   Attributes:
     output (str): Accumulated text content.
   """
-  output = ''
+
+  def __init__(self) -> None:
+    super().__init__()
+    self.output = ''
+    self.skip_stack: typing.List[str] = []
+
+  def handle_starttag(self, tag: str, attrs: HTMLAttr) -> None:
+    if tag.upper() in SKIP_NODES:
+      self.skip_stack.append(tag)
+
+  def handle_endtag(self, tag: str) -> None:
+    if self.skip_stack and self.skip_stack[-1] == tag:
+      self.skip_stack.pop()
 
   def handle_data(self, data: str) -> None:
-    self.output += data
+    if not self.skip_stack:
+      self.output += data
 
 
 class HTMLChunkResolver(HTMLParser):
   """An HTML parser to resolve the given HTML string and semantic chunks.
-
-  Attributes:
-    output (str): The HTML string to output.
   """
-  output = ''
 
   def __init__(self, chunks: typing.List[str], separator: str):
     """Initializes the parser.
@@ -70,6 +79,7 @@ class HTMLChunkResolver(HTMLParser):
       separator (str): The separator string.
     """
     HTMLParser.__init__(self)
+    self.output = ''
     self.chunks_joined = SEP.join(chunks)
     self.separator = separator
     self.to_skip = False
@@ -86,9 +96,6 @@ class HTMLChunkResolver(HTMLParser):
     encoded_attrs = ''.join(attr_pairs)
     self.element_stack.put(ElementState(tag, self.to_skip))
     if tag.upper() in SKIP_NODES:
-      if not self.to_skip and self.chunks_joined[self.scan_index] == SEP:
-        self.scan_index += 1
-        self.output += self.separator
       self.to_skip = True
     self.output += '<%s%s>' % (tag, encoded_attrs)
 
@@ -108,8 +115,11 @@ class HTMLChunkResolver(HTMLParser):
 
   def handle_data(self, data: str) -> None:
     for char in data:
-      if not char == self.chunks_joined[self.scan_index]:
-        if not self.to_skip and not char.isspace():
+      if self.to_skip:
+        self.output += char
+        continue
+      if self.scan_index < len(self.chunks_joined) and not char == self.chunks_joined[self.scan_index]:
+        if not char.isspace():
           self.output += self.separator
         self.scan_index += 1
       self.output += char

--- a/java/src/main/java/com/google/budoux/HTMLProcessor.java
+++ b/java/src/main/java/com/google/budoux/HTMLProcessor.java
@@ -64,6 +64,7 @@ final class HTMLProcessor {
    */
   private static class TextizeNodeVisitor implements NodeVisitor {
     private StringBuilder output = new StringBuilder();
+    private int skipStack = 0;
 
     public String getString() {
       return output.toString();
@@ -73,16 +74,28 @@ final class HTMLProcessor {
     public void head(Node node, int depth) {
       if (node instanceof Element) {
         final String nodeName = node.nodeName();
+        if (skipNodes.contains(nodeName.toUpperCase(Locale.ENGLISH))) {
+          skipStack++;
+        }
         if (nodeName.equals("br")) {
           output.append('\n');
         }
       } else if (node instanceof TextNode) {
-        output.append(((TextNode) node).getWholeText());
+        if (skipStack == 0) {
+          output.append(((TextNode) node).getWholeText());
+        }
       }
     }
 
     @Override
-    public void tail(Node node, int depth) {}
+    public void tail(Node node, int depth) {
+      if (node instanceof Element) {
+        final String nodeName = node.nodeName();
+        if (skipNodes.contains(nodeName.toUpperCase(Locale.ENGLISH))) {
+          skipStack--;
+        }
+      }
+    }
   }
 
   private static class PhraseResolvingNodeVisitor implements NodeVisitor {
@@ -131,22 +144,20 @@ final class HTMLProcessor {
           // Assume phrasesJoined.charAt(scanIndex) == '\n'.
           scanIndex++;
         } else if (skipNodes.contains(nodeName.toUpperCase(Locale.ENGLISH))) {
-          if (!toSkip
-              && scanIndex < phrasesJoined.length()
-              && phrasesJoined.charAt(scanIndex) == SEP) {
-            output.append(separator);
-            scanIndex++;
-          }
           toSkip = true;
         }
         output.append(String.format("<%s%s>", nodeName, attributesEncoded));
       } else if (node instanceof TextNode) {
         String data = ((TextNode) node).getWholeText();
+        if (toSkip) {
+          output.append(data);
+          return;
+        }
         for (int i = 0; i < data.length(); i++) {
           char c = data.charAt(i);
-          if (c != phrasesJoined.charAt(scanIndex)) {
+          if (scanIndex < phrasesJoined.length() && c != phrasesJoined.charAt(scanIndex)) {
             // Assume phrasesJoined.charAt(scanIndex) == SEP.
-            if (!toSkip && !Character.isWhitespace(c)) {
+            if (!Character.isWhitespace(c)) {
               output.append(separator);
             }
             scanIndex++;

--- a/java/src/test/java/com/google/budoux/HTMLProcessorConsistencyTest.java
+++ b/java/src/test/java/com/google/budoux/HTMLProcessorConsistencyTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.budoux;
+
+import static org.junit.Assert.assertEquals;
+
+import com.google.gson.Gson;
+import java.io.IOException;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Consistency tests for {@link HTMLProcessor}. */
+@RunWith(JUnit4.class)
+public class HTMLProcessorConsistencyTest {
+
+  static class TestCase {
+    String description;
+    String html;
+    String expected;
+  }
+
+  @Test
+  public void testSharedCases() throws IOException {
+    Gson gson = new Gson();
+    String jsonPath = "../tests/html_processor_shared_results.json";
+    Reader reader = Files.newBufferedReader(Paths.get(jsonPath), StandardCharsets.UTF_8);
+    TestCase[] testCases = gson.fromJson(reader, TestCase[].class);
+
+    // We use the default Japanese parser for these tests.
+    // For simplicity, we assume the model is loaded correctly.
+    Parser parser = Parser.loadDefaultJapaneseParser();
+
+    for (TestCase tc : testCases) {
+      String text = HTMLProcessor.getText(tc.html);
+      List<String> chunks = parser.parse(text);
+      String result = HTMLProcessor.resolve(chunks, tc.html, "\u200b");
+      String expectedWrapped = "<span style=\"word-break: keep-all; overflow-wrap: anywhere;\">" + tc.expected + "</span>";
+      assertEquals("Failed consistency case: " + tc.description, expectedWrapped, result);
+    }
+  }
+}

--- a/java/src/test/java/com/google/budoux/HTMLProcessorTest.java
+++ b/java/src/test/java/com/google/budoux/HTMLProcessorTest.java
@@ -68,34 +68,34 @@ public class HTMLProcessorTest {
 
   @Test
   public void testResolveWithNodesToSkip() {
-    List<String> phrases = Arrays.asList("abc", "def", "ghi");
+    List<String> phrases = Arrays.asList("a", "fghi");
     String html = "a<button>bcde</button>fghi";
     String result = HTMLProcessor.resolve(phrases, html, "<wbr>");
-    assertEquals(this.wrap("a<button>bcde</button>f<wbr>ghi"), result);
+    assertEquals(this.wrap("a<button>bcde</button><wbr>fghi"), result);
   }
 
   @Test
   public void testResolveWithNodesBreakBeforeSkip() {
-    List<String> phrases = Arrays.asList("abc", "def", "ghi", "jkl");
+    List<String> phrases = Arrays.asList("abc", "jkl");
     String html = "abc<nobr>defghi</nobr>jkl";
     String result = HTMLProcessor.resolve(phrases, html, "<wbr>");
-    assertEquals(this.wrap("abc<wbr><nobr>defghi</nobr><wbr>jkl"), result);
+    assertEquals(this.wrap("abc<nobr>defghi</nobr><wbr>jkl"), result);
   }
 
   @Test
   public void testResolveWithAfterSkip() {
-    List<String> phrases = Arrays.asList("abc", "def", "ghi", "jkl");
+    List<String> phrases = Arrays.asList("abc", "ghi", "jkl");
     String html = "abc<nobr>def</nobr>ghijkl";
     String result = HTMLProcessor.resolve(phrases, html, "<wbr>");
-    assertEquals(this.wrap("abc<wbr><nobr>def</nobr><wbr>ghi<wbr>jkl"), result);
+    assertEquals(this.wrap("abc<nobr>def</nobr><wbr>ghi<wbr>jkl"), result);
   }
 
   @Test
   public void testResolveWithAfterSkipWithImg() {
-    List<String> phrases = Arrays.asList("abc", "def", "ghi", "jkl");
+    List<String> phrases = Arrays.asList("abc", "ghi", "jkl");
     String html = "abc<nobr>d<img>ef</nobr>ghijkl";
     String result = HTMLProcessor.resolve(phrases, html, "<wbr>");
-    assertEquals(this.wrap("abc<wbr><nobr>d<img>ef</nobr><wbr>ghi<wbr>jkl"), result);
+    assertEquals(this.wrap("abc<nobr>d<img>ef</nobr><wbr>ghi<wbr>jkl"), result);
   }
 
   @Test
@@ -120,7 +120,7 @@ public class HTMLProcessorTest {
   public void testGetText() {
     String html = "Hello <button><b>W</b>orld</button>!";
     String result = HTMLProcessor.getText(html);
-    assertEquals("Hello World!", result);
+    assertEquals("Hello !", result);
   }
 
   @Test

--- a/tests/html_processor_shared_results.json
+++ b/tests/html_processor_shared_results.json
@@ -1,0 +1,32 @@
+[
+  {
+    "description": "Simple text",
+    "html": "今日は晴れです",
+    "expected": "今日は​晴れです"
+  },
+  {
+    "description": "With span (Inline)",
+    "html": "今日<span>は</span>晴れです",
+    "expected": "今日<span>は</span>​晴れです"
+  },
+  {
+    "description": "With code (Skip)",
+    "html": "今日<code>は</code>晴れです",
+    "expected": "今​日<code>は</code>​晴れです"
+  },
+  {
+    "description": "With nested skip",
+    "html": "abc<code>def</code>ghi",
+    "expected": "abc<code>def</code>ghi"
+  },
+  {
+    "description": "Void tag",
+    "html": "今日<img>晴れです",
+    "expected": "今​日<img>​晴れです"
+  },
+  {
+    "description": "Multiple chunks across tags",
+    "html": "今日は<b>晴れ</b>です",
+    "expected": "今日は<b>​晴れ</b>です"
+  }
+]

--- a/tests/test_html_processor.py
+++ b/tests/test_html_processor.py
@@ -35,6 +35,15 @@ class TestTextContentExtractor(unittest.TestCase):
         extractor.output, expected,
         'Text content should be extacted from the given HTML string.')
 
+  def test_skip_nodes(self) -> None:
+    input = '<p>Hello, <code>ignored</code>World</p>'
+    expected = 'Hello, World'
+    extractor = html_processor.TextContentExtractor()
+    extractor.feed(input)
+    self.assertEqual(
+        extractor.output, expected,
+        'Text content inside skip nodes should be ignored.')
+
 
 class TestHTMLChunkResolver(unittest.TestCase):
 
@@ -57,7 +66,8 @@ class TestHTMLChunkResolver(unittest.TestCase):
   def test_nobr(self) -> None:
     input = '<p>ab<nobr>cde</nobr>f</p>'
     expected = '<p>ab<nobr>cde</nobr>f</p>'
-    resolver = html_processor.HTMLChunkResolver(['abc', 'def'], '<wbr>')
+    # Chunks are matched against the text excluding skip nodes ("abf")
+    resolver = html_processor.HTMLChunkResolver(['abf'], '<wbr>')
     resolver.feed(input)
     self.assertEqual(resolver.output, expected,
                      'WBR tags should not be inserted if in NOBR.')
@@ -65,7 +75,8 @@ class TestHTMLChunkResolver(unittest.TestCase):
   def test_after_nobr(self) -> None:
     input = '<p>ab<nobr>xy</nobr>abcdef</p>'
     expected = '<p>ab<nobr>xy</nobr>abc<wbr>def</p>'
-    resolver = html_processor.HTMLChunkResolver(['abxyabc', 'def'], '<wbr>')
+    # Chunks are matched against the text excluding skip nodes ("ababcdef")
+    resolver = html_processor.HTMLChunkResolver(['ababc', 'def'], '<wbr>')
     resolver.feed(input)
     self.assertEqual(resolver.output, expected,
                      'WBR tags should be inserted if after NOBR.')
@@ -73,7 +84,10 @@ class TestHTMLChunkResolver(unittest.TestCase):
   def test_img_in_nobr(self) -> None:
     input = '<p>ab<nobr>x<img>y</nobr>abcdef</p>'
     expected = '<p>ab<nobr>x<img>y</nobr>abc<wbr>def</p>'
-    resolver = html_processor.HTMLChunkResolver(['abxyabc', 'def'], '<wbr>')
+    # Chunks are matched against the text excluding skip nodes ("ababcdef")
+    # Note: IMG is NOT a skip node by default in skip_nodes.json,
+    # but here it's inside NOBR which IS a skip node.
+    resolver = html_processor.HTMLChunkResolver(['ababc', 'def'], '<wbr>')
     resolver.feed(input)
     self.assertEqual(resolver.output, expected,
                      'IMG should not affect surrounding NOBR.')
@@ -96,17 +110,21 @@ class TestResolve(unittest.TestCase):
     self.assertEqual(result, expected)
 
   def test_with_nodes_to_skip(self) -> None:
-    chunks = ['abc', 'def', 'ghi']
+    # 'bcde' is inside <button> which is a skip node. 
+    # Text content for segmentation is 'afghi'.
+    chunks = ['a', 'fghi']
     html = "a<button>bcde</button>fghi"
     result = html_processor.resolve(chunks, html)
-    expected = '<span style="word-break: keep-all; overflow-wrap: anywhere;">a<button>bcde</button>f\u200bghi</span>'
+    expected = '<span style="word-break: keep-all; overflow-wrap: anywhere;">a<button>bcde</button>\u200bfghi</span>'
     self.assertEqual(result, expected)
 
   def test_with_break_before_skip(self) -> None:
-    chunks = ['abc', 'def', 'ghi', 'jkl']
+    # 'defghi' is inside <button> which is a skip node.
+    # Text content for segmentation is 'abcjkl'.
+    chunks = ['abc', 'jkl']
     html = "abc<button>defghi</button>jkl"
     result = html_processor.resolve(chunks, html)
-    expected = '<span style="word-break: keep-all; overflow-wrap: anywhere;">abc\u200b<button>defghi</button>\u200bjkl</span>'
+    expected = '<span style="word-break: keep-all; overflow-wrap: anywhere;">abc<button>defghi</button>\u200bjkl</span>'
     self.assertEqual(result, expected)
 
   def test_with_nothing_to_split(self) -> None:

--- a/tests/test_html_processor_consistency.py
+++ b/tests/test_html_processor_consistency.py
@@ -1,0 +1,69 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"Tests the HTML Processor consistency across ports."
+
+import json
+import os
+import sys
+import unittest
+from typing import List
+
+# module hack
+LIB_PATH = os.path.join(os.path.dirname(__file__), '..')
+sys.path.insert(0, os.path.abspath(LIB_PATH))
+
+from budoux import html_processor  # noqa (module hack)
+from budoux import parser  # noqa (module hack)
+
+class MockParser:
+  def __init__(self, chunks: List[str]):
+    self.chunks = chunks
+  def parse(self, text: str) -> List[str]:
+    return self.chunks
+
+class TestHTMLProcessorConsistency(unittest.TestCase):
+
+  def test_shared_cases(self) -> None:
+    shared_json_path = os.path.join(os.path.dirname(__file__), 'html_processor_shared_results.json')
+    with open(shared_json_path, encoding='utf-8') as f:
+      test_cases = json.load(f)
+
+    for case in test_cases:
+      with self.subTest(description=case['description']):
+        html = case['html']
+        expected_inner = case['expected']
+        
+        # We need to simulate the segmentation results that JS got.
+        # JS uses the real Japanese parser, but for these tests we can just
+        # provide the chunks that would result in the expected behavior.
+        # Actually, let's just use the real parser for "Simple text" etc.
+        # But to be safe and port-independent, we should probably mock the parser
+        # if the test case specifies chunks. 
+        # Our current JSON doesn't specify chunks, it's based on the real Japanese parser.
+        
+        # Let's extract the "text content" as the Python port currently does.
+        text = html_processor.get_text(html)
+        # We'll use a real parser for Japanese as the JS port does.
+        from budoux import load_default_japanese_parser
+        jp_parser = load_default_japanese_parser()
+        chunks = jp_parser.parse(text)
+        
+        # Use resolver directly to get inner HTML
+        resolver = html_processor.HTMLChunkResolver(chunks, '\u200b')
+        resolver.feed(html)
+        self.assertEqual(resolver.output, expected_inner, 
+                         f"Failed consistency case: {case['description']}\nInput: {html}\nText: {text}\nChunks: {chunks}")
+
+if __name__ == '__main__':
+  unittest.main()


### PR DESCRIPTION
This PR aligns the behavior of HTMLProcessor in Python and Java ports with the JS port.

Specifically:
- Skip nodes (e.g., <code>, ABBR) content is now ignored during text extraction and segmentation, consistent with the JS port.
- Shared consistency test cases (JSON) have been added and verified for both Python and Java.
- Existing tests have been updated to reflect the aligned behavior.

### Commits
1. Add shared consistency test cases and runner for Python.
2. Fix Python HTMLProcessor and update tests.
3. Fix Java HTMLProcessor and update tests.