### PR TITLE
fix(eval): fix TSV parsing in evaluate_model.py and add unit tests

### DIFF
--- a/scripts/evaluate_model.py
+++ b/scripts/evaluate_model.py
@@ -34,7 +34,10 @@ def evaluate(model_path: str, test_data_path: str) -> typing.Dict[str, float]:
 
   Args:
     model_path (str): Path to the compiled model JSON file.
-    test_data_path (str): Path to the raw test dataset.
+    test_data_path (str): Path to the test dataset file. Each line must contain
+      one sentence split by '▁' (U+2581). For '.tsv' files, comment lines
+      starting with '#' are ignored, and only the last column after tab
+      splitting is evaluated.
 
   Returns:
     Dict[str, float]: A dictionary containing precision, recall, accuracy,
@@ -49,13 +52,21 @@ def evaluate(model_path: str, test_data_path: str) -> typing.Dict[str, float]:
   fp = 0
   fn = 0
 
+  is_tsv = test_data_path.endswith('.tsv')
   with open(test_data_path, encoding='utf-8') as f:
     for line in f:
       line = line.strip()
-      if not line:
+      if not line or line.startswith('#'):
         continue
+      if is_tsv or '\t' in line:
+        parts = line.split('\t')
+        if len(parts) >= 2:
+          line = parts[-1].strip()
+        if not line:
+          continue
 
       # Parse raw characters and ground truth break positions
+
       raw_chars: typing.List[str] = []
       ground_truth_breaks: typing.List[bool] = []
       next_is_break = False
@@ -106,7 +117,7 @@ def evaluate(model_path: str, test_data_path: str) -> typing.Dict[str, float]:
       'accuracy': accuracy,
       'precision': precision,
       'recall': recall,
-      'fscore': fscore
+      'fscore': fscore,
   }
 
 
@@ -121,9 +132,10 @@ def main() -> None:
       '-t',
       '--test-data',
       required=True,
-      help=('Path to the test dataset file. The file must contain one sentence '
-            'per line, with target segmentations split by the canonical '
-            'separator character "▁".'),
+      help=('Path to the test dataset file. Each line must contain one '
+            'sentence split by "▁". For .tsv files, lines starting with "#" '
+            'are ignored and only the last column after tab splitting is '
+            'evaluated.'),
   )
   args = parser.parse_args()
 

--- a/scripts/tests/test_evaluate_model.py
+++ b/scripts/tests/test_evaluate_model.py
@@ -117,6 +117,22 @@ class TestEvaluateModel(unittest.TestCase):
     self.assertAlmostEqual(metrics['recall'], 1.0)
     self.assertAlmostEqual(metrics['fscore'], 1.0)
 
+  def test_evaluate_model_tsv_format(self) -> None:
+    tsv_path = os.path.join(self.temp_dir.name, 'test_data.tsv')
+    test_content = (
+        '# comment line\n'
+        f'gh123\tB{budoux.utils.SEP}A{budoux.utils.SEP}B{budoux.utils.SEP}A\n'
+        f'gh124\tmeta_info\tB{budoux.utils.SEP}A{budoux.utils.SEP}B{budoux.utils.SEP}A\n'
+    )
+    with open(tsv_path, 'w', encoding='utf-8') as f:
+      f.write(test_content)
+
+    metrics = evaluate_model.evaluate(self.model_path, tsv_path)
+    self.assertAlmostEqual(metrics['accuracy'], 2 / 3)
+    self.assertAlmostEqual(metrics['precision'], 1.0)
+    self.assertAlmostEqual(metrics['recall'], 2 / 3)
+    self.assertAlmostEqual(metrics['fscore'], 0.8)
+
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
- Support TSV format by stripping column 0 and evaluating only the last column
- Ignore comment lines starting with #
- Add unit test suite for TSV format validation

TAG=agy
CONV=af16f8d5-a8c2-4260-82a9-9617e2ba2480