### PR TITLE
Introduce synthesis and retraining piplines

### DIFF
--- a/.github/workflows/py-unittest.yml
+++ b/.github/workflows/py-unittest.yml
@@ -37,8 +37,9 @@ jobs:
       - name: Run unittest
         run: pytest ./tests
       - name: Install Jax
-        if:  ${{ matrix.os != 'windows-latest' && matrix.python-version != '3.10' }}
+        if:  ${{ matrix.os != 'windows-latest' && matrix.python-version != '3.10' && matrix.python-version != '3.11' }}
         run: pip install ".[jaxcpu]"
       - name: Run unittest with Jax
-        if:  ${{ matrix.os != 'windows-latest' && matrix.python-version != '3.10' }}
+        if:  ${{ matrix.os != 'windows-latest' && matrix.python-version != '3.10' && matrix.python-version != '3.11' }}
         run: pytest ./scripts/tests
+

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -2,21 +2,223 @@
 
 This directory is a collection of scripts to generate BudouX model files.
 The figure below provides an overview of how each script transforms data files,
-from corpora to machine learning models.
+from corpora and LLM synthetic sample generation to compiled machine learning models.
 
 ```mermaid
-flowchart
-    corpus[(Corpus)] --> prepare[prepare_*.py]
-    prepare --> source[\Source text file\]
-    source --> encode[encode_data.py]
-    encode --> encoded[\Encoded data file\]
-    encoded --> train[train.py]
-    train --> weights[\Weight file\]
-    weights --> build[build_model.py]
-    build --> model[\Model file - JSON\]
-    model --> translate[translate_model.py]
-    translate --> modelx[\Model file - Other formats\]
+flowchart TB
+    %% Phase 1: External KNBC Corpus Preparation
+    subgraph P1 ["1. KNBC External Corpus Preparation (Git-Ignored / Local Cache)"]
+        direction TB
+        KNBC_RAW["curl Download<br>KNBC_v1.0_090925_utf8.tar.bz2"] --> KNBC_PREP["prepare_knbc.py"]
+        KNBC_PREP --> KNBC_SRC["source_knbc.txt<br>(Full Unsplit Corpus)"]
+        
+        KNBC_PREP -->|"80% Split (--split-dir, shuffled)"| KNBC_TRAIN["knbc_train.txt"]
+        KNBC_PREP -->|"10% Split (--split-dir, shuffled)"| KNBC_VAL["knbc_val.txt"]
+        KNBC_PREP -->|"10% Split (--split-dir, shuffled)"| KNBC_TEST["knbc_test.txt<br>(Generalization Benchmark)"]
+    end
+
+    %% Phase 2: Agentic Synthetic Sample Generation
+    subgraph P2 ["2. Agentic Synthetic Sample Generation (synthesize_samples.py)"]
+        direction TB
+        CLI_IN["CLI Inputs: --issue=413,468,841<br>or --input='...'"] --> AGENT1["Agent 1: Intent Understanding<br>(extract_intent_target)"]
+        AGENT1 --> AGENT2["Agent 2: Example Generator<br>(generate_oversample_candidates)"]
+        AGENT2 --> OVERLAY["Deterministic Alignment Utility<br>(align_to_base_parser_splits)"]
+        OVERLAY --> AGENT3["Agent 3: Linguistic Expert Polisher<br>(prune_linguistic_anomalies)"]
+        AGENT3 --> STAGING_TXT["Staging Storage<br>(staging_raw.txt / Ephemeral Temp Files)"]
+    end
+
+    %% Phase 3: Human Review & Dataset Persistence
+    subgraph P3 ["3. Human Review & Dataset Persistence (Git-Tracked)"]
+        direction TB
+        STAGING_TXT --> REVIEW_GATE{"Human Sample Review Gate<br>(Yes / Edit / No)"}
+        
+        REVIEW_GATE -->|"Yes / Edit: Approved"| SYNTH_STORE["ja/issue_*.txt<br>(Issue-specific Samples)"]
+        REVIEW_GATE -->|"Append Representative Case (1 per target)"| REG_TSV["tests/quality/ja.tsv<br>(Canonical Test Suite)"]
+        REVIEW_GATE -->|"No: Rejected"| CANCEL1["Synthesis Aborted"]
+    end
+
+    %% Phase 4: Data Merging & Training Loop
+    subgraph P4 ["4. Data Merging & JAX Training Loop (pipeline_retraining.py)"]
+        direction TB
+        KNBC_TRAIN --> MERGE_DATA["Data Merging & Weighting<br>(1x base corpus, 100x curated lines)"]
+        CURATED_HIST["ja/history.txt<br>(Hand-crafted Historical Corpus)"] --> MERGE_DATA
+        SYNTH_STORE --> MERGE_DATA
+        
+        MERGE_DATA --> COMBINED_TXT["tmp_dir/weighted_train.txt"]
+        COMBINED_TXT --> ENCODE_PY["Feature Encoding<br>(run_encode_step / encode_data.py)"]
+        ENCODE_PY --> CONFLICT_PY["Conflict Resolution<br>(find_conflicts.py -t 0.8)"]
+        CONFLICT_PY --> TRAIN_PY["JAX AdaBoost Training<br>(run_train_step / train.py --iter=200000)"]
+        
+        TRAIN_PY --> BUILD_PY["Model Compilation<br>(run_build_compact_model_step / build_model.py)"]
+    end
+
+    %% Phase 5: Unified QA & Output Artifacts
+    subgraph P5 ["5. Unified QA Benchmark & Output Artifacts"]
+        direction TB
+        BUILD_PY --> TEMP_MODEL["tmp_dir/temp_model.json"]
+        TEMP_MODEL --> EVAL_PY["Model Benchmark Evaluation<br>(run_evaluation_report / evaluate_model.py -m -t)"]
+        
+        REG_TSV -->|"1. Quality & Issue Fix Regression Assertions"| EVAL_PY
+        KNBC_TEST -->|"2. Generalization F-score Measurement"| EVAL_PY
+        
+        EVAL_PY --> REPORT["Raw JSON Metrics (stdout)<br>・accuracy, precision, recall, fscore<br>+ Comparative Holdout Delta Report"]
+        REPORT --> FINAL_JSON["budoux/models/ja.json<br>(Updated Production Model)"]
+    end
+
+    %% Direct Connections (Validation Feature Encoding)
+    KNBC_VAL -->|"run_encode_step"| VAL_ENCODED["tmp_dir/val_encoded.txt"]
+    VAL_ENCODED -->|"Validation Loss Monitoring"| TRAIN_PY
+
+    %% Border Styles
+    style REVIEW_GATE stroke-width:3px
+    style REG_TSV stroke-width:3px
+    style FINAL_JSON stroke-width:3px
+    style REPORT stroke-width:2px
 ```
+
+---
+
+## Agentic Training Data Synthesis and Deterministic Retraining Pipelines
+
+When model defects or segmentation issues are reported, resolving them
+without hardcoding language-specific rules requires synthesizing targeted
+training sentences, auditing them with human review, and performing full
+AdaBoost retraining.
+
+Two decoupled meta-pipeline scripts manage this workflow:
+
+- [`pipeline_synthesis.py`](https://github.com/google/budoux/tree/main/scripts/pipeline_synthesis.py):
+  Handles synthetic sample generation, interactive human review gates, and
+  appending to `ja.tsv`.
+- [`pipeline_retraining.py`](https://github.com/google/budoux/tree/main/scripts/pipeline_retraining.py):
+  Handles deterministic 80:10:10 KNBC corpus split, separated weighted line
+  over-sampling (KNBC base corpus: 1x repetition, curated datasets: 100x
+  repetition prior to feature encoding), feature conflict resolution, AdaBoost
+  training (200,000 iterations), compact JSON export, and holdout/regression
+  comparative reports.
+
+### 1. Automated Meta-Pipeline Commands
+
+To generate synthetic samples and register them into the dataset and quality
+suites:
+
+```bash
+# Synthesize training samples for reported GitHub issues with auto-accept
+python scripts/pipeline_synthesis.py --issue=413,468,841 --lang=ja --auto-accept
+
+# Synthesize training samples directly for target phrase segmentation patterns
+python scripts/pipeline_synthesis.py --input="いよいよ/はじまる,もはや" --lang=ja --auto-accept
+```
+
+To execute deterministic model retraining and evaluation reporting:
+
+```bash
+# Deterministically split KNBC 80:10:10, encode with separated weights, train AdaBoost (200,000 iterations), and evaluate holdout/regression suites
+python scripts/pipeline_retraining.py --lang=ja --iter=200000 --feature-thres=2
+```
+
+---
+
+### 2. Manual Step-by-Step CLI Execution Flow
+
+If you prefer to execute each stage of the data flow manually, follow the
+steps below.
+
+#### Step A: Download & Prepare Baseline Corpus (3-Way Split)
+
+Fetch the raw KNBC corpus and split it into 80% Train, 10% Validation, and 10%
+Test datasets using `--split-dir`:
+
+```bash
+curl -o knbc.tar.bz2 https://nlp.ist.i.kyoto-u.ac.jp/kuntt/KNBC_v1.0_090925_utf8.tar.bz2
+tar -xf knbc.tar.bz2
+python scripts/prepare_knbc.py KNBC_v1.0_090925_utf8 -o source_knbc.txt --split-dir=tmp/splits
+# Outputs:
+# - source_knbc.txt           (Full unsplit corpus written to CWD)
+# - tmp/splits/knbc_train.txt (80% split for AdaBoost fitting)
+# - tmp/splits/knbc_val.txt   (10% split for validation loss tracking)
+# - tmp/splits/knbc_test.txt  (10% split for generalization benchmark)
+```
+
+#### Step B: Synthesize Samples with LLM Multi-Agent System
+
+Generate candidate training sentences using
+[`synthesize_samples.py`](https://github.com/google/budoux/tree/main/scripts/synthesize_samples.py):
+
+```bash
+python scripts/synthesize_samples.py --issue=468 --lang=ja --output=staging_468.txt
+```
+
+#### Step C: Store Approved Curated Datasets
+
+Save approved candidate sentences under `data/finetuning/ja/issue_468.txt`, and
+append exactly one representative test case (the first approved sample for the
+target) to root `tests/quality/ja.tsv`.
+
+#### Step D: Merge Training Sources & Encode Features
+
+Combine `KNBC Train` (`tmp/splits/knbc_train.txt`) and all curated datasets
+(`data/finetuning/ja/*.txt`) with 100x line repetition for curated bug-fix
+samples, then extract $n$-gram features:
+
+```bash
+# Combine base training corpus with 100x repeated curated datasets:
+for f in data/finetuning/ja/*.txt; do for i in {1..100}; do cat "$f"; done; done > tmp/weighted_train.txt
+cat tmp/splits/knbc_train.txt >> tmp/weighted_train.txt
+python scripts/encode_data.py tmp/weighted_train.txt -o tmp/encoded.txt
+```
+
+#### Step E: Resolve Feature Conflicts
+
+Filter out feature vector label contradictions using 80% majority
+thresholding:
+
+```bash
+python scripts/find_conflicts.py tmp/encoded.txt -o tmp/cleaned.txt -t 0.8
+```
+
+#### Step F: JAX AdaBoost Retraining & Model Building
+
+Encode the validation split (`KNBC Val`) into feature TSV format, train
+feature weight scores while monitoring validation loss, then compile the model
+JSON:
+
+```bash
+python scripts/encode_data.py tmp/splits/knbc_val.txt -o tmp/val_encoded.txt
+python scripts/train.py tmp/cleaned.txt --val-data=tmp/val_encoded.txt -o tmp/weights.txt --iter=200000 --feature-thres=2
+python scripts/build_model.py tmp/weights.txt -o budoux/models/ja.json
+```
+
+#### Step G: Benchmark & Quality Suite Evaluation
+
+Run evaluation benchmark against both `KNBC Test` (generalization F-score) and
+`tests/quality/ja.tsv` (canonical quality test suite using required `-m` and
+`-t` flags):
+
+```bash
+# Evaluate quality regression suite:
+python scripts/evaluate_model.py -m budoux/models/ja.json -t tests/quality/ja.tsv
+
+# Evaluate generalization holdout suite:
+python scripts/evaluate_model.py -m budoux/models/ja.json -t tmp/splits/knbc_test.txt
+```
+
+---
+
+## Dataset Governance & Structure (`data/finetuning/{lang}/`)
+
+Fine-tuning datasets are organized under `data/finetuning/{lang}/` to
+guarantee transparency, data lineage, and modular rollback:
+
+- `history.txt`: Hand-crafted historical fine-tuning sentences created by
+  maintainers (including merged legacy validation samples).
+- `issue_*.txt`: Isolated reviewed datasets for specific GitHub bug fixes.
+- Root `tests/quality/{lang}.tsv`: Canonical regression test suite located in
+  the repository root. Exactly one representative sample
+  (`approved_for_target[0]`) from each fixed issue is automatically appended
+  here for permanent protection in future `pytest` runs.
+
+---
 
 ## Preparing a source text
 
@@ -47,10 +249,13 @@ We picked these segmentations to provide a satisfactory reading experience in
 those languages, but you can apply another segmentation method that works best
 for your purpose when you build a custom model.
 
-You can make a source data file by hand or running data preparation scripts (`prepare_*.py`)
-that extracts segmented sentences from a corpus.
-Currently, this directory has one data preparation script, [`prepare_knbc.py`](https://github.com/google/budoux/tree/main/scripts/prepare_knbc.py),
-which generates a source text file from [Kyoto University and NTT Blog (KNBC) Corpus](https://nlp.ist.i.kyoto-u.ac.jp/kuntt/),
+You can make a source data file by hand or running data preparation scripts
+(`prepare_*.py`) that extracts segmented sentences from a corpus.
+Currently, this directory provides data preparation scripts such as
+[`prepare_knbc.py`](https://github.com/google/budoux/tree/main/scripts/prepare_knbc.py)
+and [`prepare_wisesight.py`](https://github.com/google/budoux/tree/main/scripts/prepare_wisesight.py).
+For Japanese, `prepare_knbc.py` generates a source text file from
+[Kyoto University and NTT Blog (KNBC) Corpus](https://nlp.ist.i.kyoto-u.ac.jp/kuntt/),
 which segments Japanese sentences by phrase.
 When we support other corpora as data sources, we should add the data
 preparation scripts for them in this directory with the `prepare_` prefix.
@@ -215,7 +420,8 @@ can tune, and they are what we call *weights*.
 A good nature of this algorithm is that it iteratively updates the weights from
 the most important features to the least ones.
 The training script appends the weight diffs to the output file, which is
-specified by the `--out` arg, at a frequency specified by the `--out-span` arg.
+specified by the `-o` / `--output` arg, at a frequency specified by the
+`--out-span` arg.
 Hence, you can build a model file from the output weight file even if you needed
 to interrupt the program before it ends (cf. [Anytime algorithm](https://en.wikipedia.org/wiki/Anytime_algorithm)).
 
@@ -304,7 +510,7 @@ Notice that the features are separated between the colon mark, and the latters
 are grouped by the former.
 The scores are summed up if there are multiple items that belong to the same group.
 Also, the scores are scaled and round to integers.
-We apply these conversations to make the output model file smaller and the
+We apply these conversions to make the output model file smaller and the
 inference faster.
 
 The keys in the first layer (e.g. `UW1` and `UW2`) are the feature types that
@@ -323,7 +529,7 @@ python scripts/build_model.py weights.txt -o model.json
 
 JSON is the primary format for the BudouX models, but some libraries (e.g. [ICU](https://icu.unicode.org/))
 may want to use another serialization format to store  model data.
-You can translate a model JSON file to another format with [`translate.py`](https://github.com/google/budoux/tree/main/scripts/translate.py)
+You can translate a model JSON file to another format with [`translate_model.py`](https://github.com/google/budoux/tree/main/scripts/translate_model.py)
 if it's more useful for your specific purpose.
 For example, you can convert a model file to an ICU Resource Bundle by running:
 
@@ -339,7 +545,7 @@ When a model file misclassifies character transition boundaries in specific edge
 cases (for example, missing phrase segmentations across newly observed character
 combinations), resolving the discrepancy requires performing full AdaBoost
 linear retraining using `train.py` across updated feature records
-(`encoded_data.txt`).
+(`encoded.txt`).
 
 Historically, partial gradient-descent fine-tuning over established base JSON
 models (`finetune.py`) was supported. However, because partial fine-tuning

--- a/scripts/pipeline_retraining.py
+++ b/scripts/pipeline_retraining.py
@@ -1,0 +1,497 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Deterministic model retraining meta-pipeline orchestrator.
+
+Implements deterministic 80:10:10 KNBC corpus split, separated weighted
+encoding (KNBC: scale 1, curated data: scale 100), feature
+conflict resolution (-t 0.8), AdaBoost training with 200,000 iterations
+(--feature-thres 2), compact JSON export, and holdout/regression
+comparative evaluation reports.
+"""
+
+import argparse
+import glob
+import json
+import os
+import random
+import sys
+import tempfile
+from typing import Any, Dict, List, Optional, Tuple
+
+# Module hack to allow importing scripts and budoux from workspace root
+LIB_PATH = os.path.join(os.path.dirname(__file__), '..')
+sys.path.insert(0, os.path.abspath(LIB_PATH))
+
+from scripts import build_model  # noqa: E402
+from scripts import encode_data  # noqa: E402
+from scripts import evaluate_model  # noqa: E402
+from scripts import find_conflicts  # noqa: E402
+from scripts import train  # noqa: E402
+
+
+def deterministic_split_corpus(
+    source_path: str,
+    output_dir: str,
+    lang: str = "ja",
+    train_ratio: float = 0.80,
+    val_ratio: float = 0.10,
+    test_ratio: float = 0.10,
+    seed: int = 42,
+) -> Tuple[str, str, str]:
+  """Splits corpus deterministically (shuffled with seed) into 80:10:10 subsets.
+
+  Args:
+    source_path: Path to the source corpus file.
+    output_dir: Destination directory for split files.
+    lang: Language code.
+    train_ratio: Proportion of training samples (default 0.80).
+    val_ratio: Proportion of validation samples (default 0.10).
+    test_ratio: Proportion of test samples (default 0.10).
+    seed: Random seed for reproducible shuffling (default 42).
+
+  Returns:
+    Tuple of paths to (train_path, val_path, test_path).
+  """
+  os.makedirs(output_dir, exist_ok=True)
+  train_filename = f"{lang}_train.txt" if lang != "ja" else "knbc_train.txt"
+  val_filename = f"{lang}_val.txt" if lang != "ja" else "knbc_val.txt"
+  test_filename = f"{lang}_test.txt" if lang != "ja" else "knbc_test.txt"
+
+  train_path = os.path.join(output_dir, train_filename)
+  val_path = os.path.join(output_dir, val_filename)
+  test_path = os.path.join(output_dir, test_filename)
+
+  with open(source_path, "r", encoding="utf-8") as f:
+    lines = [line.strip() for line in f if line.strip()]
+
+  rng = random.Random(seed)
+  rng.shuffle(lines)
+
+  total = len(lines)
+  n_train = int(total * train_ratio)
+  n_val = int(total * val_ratio)
+
+  train_lines = lines[:n_train]
+  val_lines = lines[n_train:n_train + n_val]
+  test_lines = lines[n_train + n_val:]
+
+  for path, split_lines in [
+      (train_path, train_lines),
+      (val_path, val_lines),
+      (test_path, test_lines),
+  ]:
+    with open(path, "w", encoding="utf-8") as f:
+      for line in split_lines:
+        f.write(line + "\n")
+
+  print(f"[Split Corpus] Split {total} sentences deterministically "
+        f"(Train: {len(train_lines)}, Val: {len(val_lines)}, "
+        f"Test: {len(test_lines)}) into {output_dir}.")
+  return train_path, val_path, test_path
+
+
+def ensure_base_datasets(
+    lang: str = "ja",
+    split_dir: Optional[str] = None,
+) -> Tuple[Optional[str], Optional[str], Optional[str]]:
+  """Ensures baseline corpus 80:10:10 split files exist for the target language."""
+  if not split_dir:
+    split_dir = os.path.abspath(
+        os.path.join(os.path.dirname(__file__), "..", "tmp", "splits"))
+
+  train_filename = f"{lang}_train.txt" if lang != "ja" else "knbc_train.txt"
+  val_filename = f"{lang}_val.txt" if lang != "ja" else "knbc_val.txt"
+  test_filename = f"{lang}_test.txt" if lang != "ja" else "knbc_test.txt"
+
+  train_path = os.path.join(split_dir, train_filename)
+  val_path = os.path.join(split_dir, val_filename)
+  test_path = os.path.join(split_dir, test_filename)
+
+  if all(os.path.exists(p) for p in (train_path, val_path, test_path)):
+    return train_path, val_path, test_path
+
+  if lang == "ja":
+    print("[Base Corpus] KNBC 80:10:10 dataset splits not found. Preparing...")
+    import tarfile
+    import urllib.request
+
+    from scripts import prepare_knbc  # noqa: E402
+
+    tmp_dir = os.path.abspath(
+        os.path.join(os.path.dirname(__file__), "..", "tmp"))
+    os.makedirs(tmp_dir, exist_ok=True)
+    knbc_dir = os.path.join(tmp_dir, "KNBC_v1.0_090925_utf8")
+
+    if not os.path.exists(knbc_dir):
+      tar_path = os.path.join(tmp_dir, "knbc.tar.bz2")
+      if not os.path.exists(tar_path):
+        url = (
+            "https://nlp.ist.i.kyoto-u.ac.jp/kuntt/KNBC_v1.0_090925_utf8.tar.bz2"
+        )
+        print(f"[Base Corpus] Downloading raw KNBC corpus from {url}...")
+        urllib.request.urlretrieve(url, tar_path)
+
+      print("[Base Corpus] Extracting KNBC archive...")
+      with tarfile.open(tar_path, "r:bz2") as tar:
+        tar.extractall(path=tmp_dir)
+
+    source_knbc_path = os.path.join(tmp_dir, "source_knbc.txt")
+    prepare_knbc.process_knbc(
+        source_dir=knbc_dir,
+        outfile=source_knbc_path,
+    )
+
+    if os.path.exists(source_knbc_path):
+      return deterministic_split_corpus(
+          source_path=source_knbc_path,
+          output_dir=split_dir,
+          lang=lang,
+          train_ratio=0.80,
+          val_ratio=0.10,
+          test_ratio=0.10,
+      )
+
+  return None, None, None
+
+
+def merge_and_weight_training_sources(
+    lang: str,
+    output_path: str,
+    base_train_path: Optional[str] = None,
+    base_scale: int = 1,
+    curated_scale: int = 100,
+) -> str:
+  """Separated weighted merge: base corpus (scale 1) and curated data (scale 100)."""
+  combined: List[str] = []
+
+  # 1. Base KNBC corpus lines repeated base_scale times
+  if base_train_path and os.path.exists(base_train_path):
+    with open(base_train_path, "r", encoding="utf-8") as f:
+      base_lines = [line.strip() for line in f if line.strip()]
+      for _ in range(base_scale):
+        combined.extend(base_lines)
+
+  # 2. Curated & reviewed samples repeated curated_scale times
+  lang_dir = os.path.join(
+      os.path.dirname(__file__), "..", "data", "finetuning", lang)
+  if os.path.exists(lang_dir):
+    for curated_file in sorted(glob.glob(os.path.join(lang_dir, "*.txt"))):
+      with open(curated_file, "r", encoding="utf-8") as f:
+        curated_lines = [line.strip() for line in f if line.strip()]
+        for _ in range(curated_scale):
+          combined.extend(curated_lines)
+
+  with open(output_path, "w", encoding="utf-8") as f:
+    f.write("\n".join(combined) + "\n")
+
+  print(f"[Merge & Weight] Generated separated weighted training dataset "
+        f"({len(combined)} total lines) at {output_path}.")
+  return output_path
+
+
+def run_encode_step(source_path: str, encoded_out_path: str) -> None:
+  """Runs feature encoding."""
+  encode_data.main([source_path, "-o", encoded_out_path])
+
+
+def run_find_conflicts_step(encoded_path: str,
+                            cleaned_path: str,
+                            threshold: float = 0.8) -> None:
+  """Resolves feature conflicts at the specified threshold."""
+  find_conflicts.find_conflicts(
+      data_path=encoded_path, output_path=cleaned_path, threshold=threshold)
+
+
+def run_train_step(
+    cleaned_encoded_path: str,
+    weights_out_path: str,
+    log_out_path: str,
+    iterations: int = 200000,
+    feature_thres: int = 2,
+    val_data_path: Optional[str] = None,
+) -> None:
+  """Trains AdaBoost weights using JAX."""
+  val_encoded_path: Optional[str] = None
+  if val_data_path and os.path.exists(val_data_path):
+    with tempfile.NamedTemporaryFile(suffix=".txt", delete=False) as tmp:
+      val_encoded_path = tmp.name
+    run_encode_step(val_data_path, val_encoded_path)
+
+  try:
+    dataset_train, features, dataset_val = train.preprocess(
+        train_data_path=cleaned_encoded_path,
+        feature_thres=feature_thres,
+        val_data_path=val_encoded_path,
+    )
+    out_span = max(1, iterations // 10)
+    train.fit(
+        dataset_train=dataset_train,
+        dataset_val=dataset_val,
+        features=features,
+        iters=iterations,
+        weights_filename=weights_out_path,
+        log_filename=log_out_path,
+        out_span=out_span,
+    )
+  finally:
+    if val_encoded_path and os.path.exists(val_encoded_path):
+      os.remove(val_encoded_path)
+
+
+def run_build_compact_model_step(
+    weights_path: str,
+    model_json_out_path: str,
+    scale: int = 1000,
+) -> Dict[str, Dict[str, int]]:
+  """Compiles weights into a compact JSON model representation."""
+  with open(weights_path, "r", encoding="utf-8") as f:
+    weight_lines = f.readlines()
+
+  aggregated = build_model.aggregate_scores(weight_lines)
+  rounded = build_model.round_model(aggregated, scale=scale)
+
+  os.makedirs(
+      os.path.dirname(os.path.abspath(model_json_out_path)), exist_ok=True)
+  with open(model_json_out_path, "w", encoding="utf-8") as f:
+    json.dump(rounded, f, ensure_ascii=False, separators=(",", ":"))
+
+  print(f"[Build Model] Exported compact model JSON to {model_json_out_path}.")
+  return rounded
+
+
+def run_evaluation_report(
+    model_path: str,
+    holdout_test_path: Optional[str] = None,
+    regression_tsv_path: Optional[str] = None,
+    baseline_model_path: Optional[str] = None,
+) -> Dict[str, Any]:
+  """Runs holdout and regression evaluation benchmarks and logs comparative reports."""
+  reports: Dict[str, Any] = {}
+
+  if holdout_test_path and os.path.exists(holdout_test_path):
+    print("\n=== Holdout Benchmark Report (Generalization) ===")
+    h_metrics = evaluate_model.evaluate(model_path, holdout_test_path)
+    model_bytes = os.path.getsize(model_path)
+    h_report: Dict[str, Any] = dict(h_metrics)
+    h_report["model_file_bytes"] = model_bytes
+    h_report["model_file_kb"] = round(model_bytes / 1024.0, 2)
+    if baseline_model_path and os.path.exists(baseline_model_path):
+      b_metrics = evaluate_model.evaluate(baseline_model_path,
+                                          holdout_test_path)
+      b_bytes = os.path.getsize(baseline_model_path)
+      deltas = {
+          k: round(h_metrics[k] - b_metrics[k], 6)
+          for k in ("accuracy", "precision", "recall", "fscore")
+      }
+      deltas["model_file_bytes"] = model_bytes - b_bytes
+      h_report["baseline"] = dict(b_metrics)
+      h_report["baseline"]["model_file_bytes"] = b_bytes
+      h_report["baseline"]["model_file_kb"] = round(b_bytes / 1024.0, 2)
+      h_report["deltas"] = deltas
+    reports["holdout"] = h_report
+    print(json.dumps(h_report, indent=2))
+
+  if regression_tsv_path and os.path.exists(regression_tsv_path):
+    print("\n=== Regression Suite Report (Quality TSV) ===")
+    r_metrics = evaluate_model.evaluate(model_path, regression_tsv_path)
+    r_report: Dict[str, Any] = dict(r_metrics)
+    if baseline_model_path and os.path.exists(baseline_model_path):
+      b_r_metrics = evaluate_model.evaluate(baseline_model_path,
+                                            regression_tsv_path)
+      r_report["baseline"] = dict(b_r_metrics)
+      r_report["deltas"] = {
+          k: round(r_metrics[k] - b_r_metrics[k], 6)
+          for k in ("accuracy", "precision", "recall", "fscore")
+      }
+    reports["regression"] = r_report
+    print(json.dumps(r_report, indent=2))
+
+  return reports
+
+
+def run_retraining_pipeline(
+    lang: str = "ja",
+    iterations: int = 200000,
+    feature_thres: int = 2,
+    conflict_threshold: float = 0.8,
+    base_scale: int = 1,
+    curated_scale: int = 100,
+    output_model: Optional[str] = None,
+    min_accuracy: float = 0.0,
+    force: bool = False,
+    split_dir: Optional[str] = None,
+    regression_tsv_path: Optional[str] = None,
+) -> Dict[str, Any]:
+  """Runs deterministic model retraining meta-pipeline."""
+  if not output_model:
+    output_model = os.path.join(
+        os.path.dirname(__file__), "..", "budoux", "models", f"{lang}.json")
+  baseline_model_path = output_model if os.path.exists(output_model) else None
+
+  if not regression_tsv_path:
+    regression_tsv_path = os.path.join(
+        os.path.dirname(__file__), "..", "tests", "quality", f"{lang}.tsv")
+
+  base_train, base_val, base_test = ensure_base_datasets(
+      lang=lang, split_dir=split_dir)
+
+  with tempfile.TemporaryDirectory() as tmp_dir:
+    merged_path = os.path.join(tmp_dir, "weighted_train.txt")
+    merge_and_weight_training_sources(
+        lang=lang,
+        output_path=merged_path,
+        base_train_path=base_train,
+        base_scale=base_scale,
+        curated_scale=curated_scale,
+    )
+
+    encoded_path = os.path.join(tmp_dir, "encoded.txt")
+    run_encode_step(merged_path, encoded_path)
+
+    cleaned_path = os.path.join(tmp_dir, "cleaned.txt")
+    run_find_conflicts_step(
+        encoded_path, cleaned_path, threshold=conflict_threshold)
+
+    weights_path = os.path.join(tmp_dir, "weights.txt")
+    log_path = os.path.join(tmp_dir, "train.log")
+    run_train_step(
+        cleaned_encoded_path=cleaned_path,
+        weights_out_path=weights_path,
+        log_out_path=log_path,
+        iterations=iterations,
+        feature_thres=feature_thres,
+        val_data_path=base_val,
+    )
+
+    temp_model_path = os.path.join(tmp_dir, "temp_model.json")
+    run_build_compact_model_step(
+        weights_path=weights_path, model_json_out_path=temp_model_path)
+
+    reports = run_evaluation_report(
+        model_path=temp_model_path,
+        holdout_test_path=base_test,
+        regression_tsv_path=regression_tsv_path,
+        baseline_model_path=baseline_model_path,
+    )
+
+    # Regression check gate
+    regressed = False
+    for suite_key, m in reports.items():
+      acc = m.get("accuracy", 0.0)
+      if acc < min_accuracy:
+        regressed = True
+      if "delta_accuracy" in m and m["delta_accuracy"] < 0.0:
+        regressed = True
+
+    if regressed and not force:
+      print(
+          "[Error] Regression detected against baseline or minimum accuracy threshold."
+      )
+      return {
+          "status": "regressed",
+          "reports": reports,
+      }
+
+    # Promote compact model to target output path
+    with open(temp_model_path, "r", encoding="utf-8") as f:
+      compact_content = f.read()
+    with open(output_model, "w", encoding="utf-8") as f:
+      f.write(compact_content)
+
+    print(f"\n[Success] Updated production model at {output_model}.")
+    return {
+        "status": "completed",
+        "output_model": output_model,
+        "reports": reports,
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+  """Constructs CLI parser."""
+  p = argparse.ArgumentParser(
+      description="Deterministic model retraining meta-pipeline orchestrator.")
+  p.add_argument(
+      "--lang",
+      type=str,
+      default="ja",
+      help="Target language code (default: ja)")
+  p.add_argument(
+      "--iter",
+      type=int,
+      default=200000,
+      help="Training iterations (default: 200000)",
+  )
+  p.add_argument(
+      "--feature-thres",
+      type=int,
+      default=2,
+      help="Feature frequency threshold (default: 2)",
+  )
+  p.add_argument(
+      "--conflict-threshold",
+      type=float,
+      default=0.8,
+      help="Conflict resolution threshold (default: 0.8)",
+  )
+  p.add_argument(
+      "--base-scale",
+      type=int,
+      default=1,
+      help="Encoding weight scale for base corpus (default: 1)",
+  )
+  p.add_argument(
+      "--curated-scale",
+      type=int,
+      default=100,
+      help="Encoding weight scale for curated data (default: 100)",
+  )
+  p.add_argument(
+      "--output-model", type=str, default=None, help="Destination model path.")
+  p.add_argument(
+      "--min-accuracy",
+      type=float,
+      default=0.0,
+      help="Minimum required accuracy threshold.",
+  )
+  p.add_argument(
+      "--force",
+      action="store_true",
+      help="Force model output export even if regressed.",
+  )
+  return p
+
+
+def main() -> None:
+  """CLI entry point."""
+  parser = build_parser()
+  args = parser.parse_args()
+
+  res = run_retraining_pipeline(
+      lang=args.lang,
+      iterations=args.iter,
+      feature_thres=args.feature_thres,
+      conflict_threshold=args.conflict_threshold,
+      base_scale=args.base_scale,
+      curated_scale=args.curated_scale,
+      output_model=args.output_model,
+      min_accuracy=args.min_accuracy,
+      force=args.force,
+  )
+
+  if res.get("status") == "regressed":
+    sys.exit(1)
+
+
+if __name__ == "__main__":
+  main()

--- a/scripts/pipeline_synthesis.py
+++ b/scripts/pipeline_synthesis.py
@@ -1,0 +1,391 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Data synthesis meta-pipeline orchestrator.
+
+Generates synthetic training samples from issues or direct text inputs using
+synthesize_samples, enforces an interactive human review gate, persists
+approved datasets in curated storage, and appends samples to quality suites
+(ja.tsv) and curated history (history.txt).
+"""
+
+import argparse
+import os
+import sys
+import tempfile
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+# Module hack to allow importing scripts and budoux from workspace root
+LIB_PATH = os.path.join(os.path.dirname(__file__), '..')
+sys.path.insert(0, os.path.abspath(LIB_PATH))
+
+import budoux  # noqa: E402
+from scripts import synthesize_samples  # noqa: E402
+
+SEP = budoux.utils.SEP  # Canonical character separator '▁'
+
+
+def human_sample_review_gate(
+    synthesized_lines: List[str],
+    auto_accept: bool = False,
+    input_func: Callable[[str], str] = input,
+) -> List[str]:
+  """Human Sample Review Gate: Interactively reviews and approves candidate lines.
+
+  Args:
+    synthesized_lines: Synthesized candidate sample sentences.
+    auto_accept: If True, automatically accepts all lines without prompt.
+    input_func: Function to read user input (injectable for testing).
+
+  Returns:
+    List[str]: Approved (and potentially edited) training sample lines.
+  """
+  if not synthesized_lines:
+    print("[Human Review Gate] No synthesized lines provided for review.")
+    return []
+
+  if auto_accept:
+    print("[Human Review Gate] Auto-accept enabled. Approving all lines.")
+    return list(synthesized_lines)
+
+  print("\n=== Human Sample Review Gate ===")
+  for idx, line in enumerate(synthesized_lines, 1):
+    print(f"  [{idx}] {line}")
+
+  while True:
+    choice = (
+        input_func("\nApprove synthesized samples? ([Y]es / [e]dit / [n]o): ")
+        .strip().lower())
+    if choice in ("", "y", "yes"):
+      print("[Human Review Gate] Samples approved.")
+      return list(synthesized_lines)
+    elif choice in ("n", "no"):
+      print("[Human Review Gate] Samples rejected by maintainer.")
+      return []
+    elif choice in ("e", "edit"):
+      edited_lines = list(synthesized_lines)
+      while True:
+        print("\nCurrent candidate lines:")
+        for idx, line in enumerate(edited_lines, 1):
+          print(f"  [{idx}] {line}")
+        action = (
+            input_func(
+                "\nEnter line number to edit/delete, 'add' to insert, or 'done' to finish: "
+            ).strip().lower())
+        if action == "done":
+          print("[Human Review Gate] Editing complete. Approved edited lines.")
+          return edited_lines
+        elif action == "add":
+          new_line = input_func("Enter new sample sentence with '▁': ").strip()
+          if new_line:
+            edited_lines.append(new_line)
+        elif action.isdigit():
+          line_idx = int(action) - 1
+          if 0 <= line_idx < len(edited_lines):
+            print(f"Selected [{line_idx + 1}]: {edited_lines[line_idx]}")
+            sub_action = (
+                input_func("Choose action ([e]dit / [d]elete / [c]ancel): ")
+                .strip().lower())
+            if sub_action in ("e", "edit"):
+              val = input_func("Enter replacement sentence: ").strip()
+              if val:
+                edited_lines[line_idx] = val
+            elif sub_action in ("d", "delete"):
+              edited_lines.pop(line_idx)
+          else:
+            print("Invalid line index.")
+    else:
+      print("Invalid choice. Please enter 'y', 'e', or 'n'.")
+
+
+def register_synthetic_dataset(
+    lang: str,
+    issue_id: str,
+    approved_lines: List[str],
+) -> str:
+  """Persists approved samples into language dataset directory.
+
+  Args:
+    lang: Target language code.
+    issue_id: Issue ID (e.g. '468').
+    approved_lines: Approved synthetic lines.
+
+  Returns:
+    str: Path to written issue file in language directory.
+  """
+  lang_dir = os.path.join(
+      os.path.dirname(__file__), "..", "data", "finetuning", lang)
+  os.makedirs(lang_dir, exist_ok=True)
+
+  issue_filename = f"issue_{issue_id}.txt"
+  issue_path = os.path.join(lang_dir, issue_filename)
+  with open(issue_path, "w", encoding="utf-8") as f:
+    f.write("\n".join(approved_lines) + "\n")
+
+  print(f"[Dataset Storage] Saved dataset to {issue_path}.")
+  return issue_path
+
+
+def append_to_quality_suite(
+    lang: str,
+    issue_id: str,
+    sample_line: str,
+    quality_path: Optional[str] = None,
+) -> None:
+  """Appends a representative fix line to tests/quality/{lang}.tsv.
+
+  Args:
+    lang: Language code.
+    issue_id: Issue ID.
+    sample_line: Sample sentence with separators '▁'.
+    quality_path: Optional path to quality tsv file.
+  """
+  if not quality_path:
+    quality_path = os.path.join(
+        os.path.dirname(__file__), "..", "tests", "quality", f"{lang}.tsv")
+  if not os.path.exists(quality_path):
+    return
+
+  label = f"gh{issue_id}"
+  formatted_entry = f"{label}\t{sample_line}\n"
+
+  with open(quality_path, "r", encoding="utf-8") as f:
+    content = f.read()
+
+  if formatted_entry.strip() not in content:
+    with open(quality_path, "a", encoding="utf-8") as f:
+      f.write(formatted_entry)
+    print(
+        f"[Test Suite] Registered representative test case into {quality_path}."
+    )
+
+
+def append_to_history(
+    lang: str,
+    approved_lines: List[str],
+    history_path: Optional[str] = None,
+) -> None:
+  """Appends approved sample lines to curated history.txt.
+
+  Args:
+    lang: Target language code.
+    approved_lines: List of approved sample sentences.
+    history_path: Optional path to history file.
+  """
+  if not history_path:
+    history_path = os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "data",
+        "finetuning",
+        lang,
+        "history.txt",
+    )
+  os.makedirs(os.path.dirname(history_path), exist_ok=True)
+
+  existing_lines = set()
+  if os.path.exists(history_path):
+    with open(history_path, "r", encoding="utf-8") as f:
+      existing_lines = {line.strip() for line in f if line.strip()}
+
+  new_lines = [
+      item.strip()
+      for item in approved_lines
+      if item.strip() and item.strip() not in existing_lines
+  ]
+
+  if new_lines:
+    with open(history_path, "a", encoding="utf-8") as f:
+      for line in new_lines:
+        f.write(line + "\n")
+    print(f"[History] Appended {len(new_lines)} lines to {history_path}.")
+
+
+def run_synthesis_pipeline(
+    inputs: Optional[List[str]] = None,
+    issues: Optional[List[str]] = None,
+    lang: str = "ja",
+    num_candidates: int = 30,
+    max_keep: int = 15,
+    auto_accept: bool = False,
+    append_history: bool = True,
+    client: Optional[Any] = None,
+    parser: Optional[budoux.Parser] = None,
+    input_func: Callable[[str], str] = input,
+    quality_path: Optional[str] = None,
+    history_path: Optional[str] = None,
+) -> Dict[str, Any]:
+  """Runs the end-to-end data synthesis pipeline.
+
+  Args:
+    inputs: Target input strings.
+    issues: Target GitHub issue IDs.
+    lang: Language code.
+    num_candidates: Candidates per target.
+    max_keep: Max candidates to retain per target.
+    auto_accept: Bypass interactive prompt.
+    append_history: Whether to append approved lines to history.txt.
+    client: Optional genai.Client instance.
+    parser: Optional budoux.Parser instance.
+    input_func: Callable for reading user prompts.
+    quality_path: Optional path to quality TSV.
+    history_path: Optional path to history TXT.
+
+  Returns:
+    Dict containing synthesis status, approved sample count, and saved paths.
+  """
+  targets_to_process: List[Tuple[Optional[str], Optional[str]]] = []
+  if inputs:
+    for item_inp in inputs:
+      targets_to_process.append((item_inp, None))
+  if issues:
+    for item_iss in issues:
+      targets_to_process.append((None, item_iss))
+
+  if not targets_to_process:
+    print("[Synthesis Pipeline] No target inputs or issues provided.")
+    return {"status": "aborted", "reason": "No target inputs or issues."}
+
+  all_approved_lines: List[str] = []
+  saved_paths: List[str] = []
+
+  with tempfile.TemporaryDirectory() as tmp_dir:
+    for idx, (raw_inp, raw_iss) in enumerate(targets_to_process):
+      target_id: str = (
+          raw_iss if raw_iss is not None else f"direct_input_{idx + 1}")
+      tmp_staging = os.path.join(tmp_dir, f"staging_{target_id}.txt")
+      lines = synthesize_samples.run_agentic_synthesis_pipeline(
+          input_str=raw_inp,
+          issue_id=raw_iss,
+          num_candidates=num_candidates,
+          max_keep=max_keep,
+          lang=lang,
+          outfile=tmp_staging,
+          client=client,
+          parser=parser,
+      )
+      if not lines:
+        continue
+
+      print(
+          f"\n[Synthesis Pipeline] Reviewing candidates for target: {target_id}"
+      )
+      target_approved = human_sample_review_gate(
+          synthesized_lines=lines,
+          auto_accept=auto_accept,
+          input_func=input_func,
+      )
+      if target_approved:
+        all_approved_lines.extend(target_approved)
+        issue_path = register_synthetic_dataset(
+            lang=lang,
+            issue_id=target_id,
+            approved_lines=target_approved,
+        )
+        saved_paths.append(issue_path)
+        append_to_quality_suite(
+            lang=lang,
+            issue_id=target_id,
+            sample_line=target_approved[0],
+            quality_path=quality_path,
+        )
+
+    if not all_approved_lines:
+      print("[Synthesis Pipeline] Review rejected or no samples approved.")
+      return {
+          "status": "aborted",
+          "reason": "Human Review Gate rejected samples.",
+      }
+
+    if append_history:
+      append_to_history(
+          lang=lang,
+          approved_lines=all_approved_lines,
+          history_path=history_path,
+      )
+
+    return {
+        "status": "completed",
+        "approved_lines": all_approved_lines,
+        "approved_lines_count": len(all_approved_lines),
+        "saved_paths": saved_paths,
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+  """Constructs CLI parser."""
+  p = argparse.ArgumentParser(
+      description="Data synthesis meta-pipeline orchestrator.")
+  group = p.add_mutually_exclusive_group(required=True)
+  group.add_argument(
+      "--input",
+      "-i",
+      type=str,
+      help="Target string or comma-separated strings.",
+  )
+  group.add_argument(
+      "--issue",
+      type=str,
+      help="GitHub issue ID or comma-separated issue IDs.",
+  )
+  p.add_argument(
+      "--lang",
+      type=str,
+      default="ja",
+      help="Target language code (default: ja)",
+  )
+  p.add_argument(
+      "--num-candidates",
+      type=int,
+      default=30,
+      help="Candidates per target.",
+  )
+  p.add_argument(
+      "--max-keep", type=int, default=15, help="Max candidates per target.")
+  p.add_argument(
+      "--auto-accept",
+      action="store_true",
+      help="Bypass interactive review prompt.",
+  )
+  p.add_argument(
+      "--no-history",
+      action="store_true",
+      help="Do not append approved lines to curated history.txt.",
+  )
+  return p
+
+
+def main() -> None:
+  """CLI entry point."""
+  parser = build_parser()
+  args = parser.parse_args()
+
+  inputs = [x.strip() for x in args.input.split(",")] if args.input else None
+  issues = [x.strip() for x in args.issue.split(",")] if args.issue else None
+
+  res = run_synthesis_pipeline(
+      inputs=inputs,
+      issues=issues,
+      lang=args.lang,
+      num_candidates=args.num_candidates,
+      max_keep=args.max_keep,
+      auto_accept=args.auto_accept,
+      append_history=not args.no_history,
+  )
+
+  if res.get("status") == "aborted":
+    sys.exit(1)
+
+
+if __name__ == "__main__":
+  main()

--- a/scripts/prepare_knbc.py
+++ b/scripts/prepare_knbc.py
@@ -26,9 +26,11 @@ $ python scripts/prepare_knbc.py KNBC_v1.0_090925_utf8 -o source_knbc.txt
 
 import argparse
 import os
+import random
 import sys
 import typing
 from html.parser import HTMLParser
+from typing import Literal, Optional
 
 # module hack
 LIB_PATH = os.path.join(os.path.dirname(__file__), '..')
@@ -37,7 +39,7 @@ sys.path.insert(0, os.path.abspath(LIB_PATH))
 from budoux import utils  # noqa (module hack)
 
 GRANULARITY_OPTIONS = {'phrase', 'tag', 'word'}
-Granularity = typing.Literal['phrase', 'tag', 'word']
+Granularity = Literal['phrase', 'tag', 'word']
 
 
 class KNBCHTMLParser(HTMLParser):
@@ -160,28 +162,107 @@ word: 携帯 / ユーザー / の / 仲間 / 入り / を / する / か / で�
 ''',
       choices=GRANULARITY_OPTIONS,
       default=DEFAULT_GRANULARITY)
+  parser.add_argument(
+      '--split-dir',
+      help='Directory to output 3-way split datasets (knbc_train.txt, knbc_val.txt, knbc_test.txt).',
+      default=None)
+  parser.add_argument(
+      '--val-ratio',
+      type=float,
+      help='Ratio of validation partition (default: 0.10).',
+      default=0.10)
+  parser.add_argument(
+      '--test-ratio',
+      type=float,
+      help='Ratio of test partition (default: 0.10).',
+      default=0.10)
+  parser.add_argument(
+      '--seed',
+      type=int,
+      help='Random seed for deterministic split (default: 42).',
+      default=42)
   return parser.parse_args()
+
+
+def process_knbc(
+    source_dir: str,
+    outfile: str,
+    granularity: Granularity = 'phrase',
+    split_dir: Optional[str] = None,
+    val_ratio: float = 0.10,
+    test_ratio: float = 0.10,
+    seed: int = 42,
+) -> None:
+  """Processes KNBC HTML archives into segmented text files and optional splits."""
+  html_dir = os.path.join(source_dir, 'html')
+  sentences: list[str] = []
+  for file in sorted(os.listdir(html_dir)):
+    if file[-11:] != '-morph.html':
+      continue
+    parser = KNBCHTMLParser(granularity)
+    data = open(os.path.join(html_dir, file)).read()
+    parser.feed(data)
+    chunks = parser.chunks
+    chunks = postprocess(chunks)
+    if len(chunks) < 2:
+      continue
+    sentences.append(utils.SEP.join(chunks))
+
+  with open(outfile, 'w', encoding='utf-8') as f:
+    for s in sentences:
+      f.write(s + '\n')
+  print('\033[92mFull training data is output to: %s\033[0m' % (outfile))
+
+  if split_dir:
+    valid_ratios = (0.0 <= val_ratio <= 1.0) and (
+        0.0 <= test_ratio <= 1.0) and (val_ratio + test_ratio < 1.0)
+    if not valid_ratios:
+      raise ValueError(
+          "Invalid split ratios: val_ratio + test_ratio must be less than 1.0.")
+    os.makedirs(split_dir, exist_ok=True)
+    shuffled = sentences.copy()
+    random.seed(seed)
+    random.shuffle(shuffled)
+
+    num_total = len(shuffled)
+    num_val = int(num_total * val_ratio)
+    num_test = int(num_total * test_ratio)
+    num_train = num_total - num_val - num_test
+
+    train_sentences = shuffled[:num_train]
+    val_sentences = shuffled[num_train:num_train + num_val]
+    test_sentences = shuffled[num_train + num_val:]
+
+    train_path = os.path.join(split_dir, 'knbc_train.txt')
+    val_path = os.path.join(split_dir, 'knbc_val.txt')
+    test_path = os.path.join(split_dir, 'knbc_test.txt')
+
+    for path, split_lines in [
+        (train_path, train_sentences),
+        (val_path, val_sentences),
+        (test_path, test_sentences),
+    ]:
+      with open(path, 'w', encoding='utf-8') as f:
+        for line in split_lines:
+          f.write(line + '\n')
+
+    print(
+        '\033[92m3-Way split dataset written to %s:\n  Train: %s (%d lines)\n  Val:   %s (%d lines)\n  Test:  %s (%d lines)\033[0m'
+        % (split_dir, train_path, len(train_sentences), val_path,
+           len(val_sentences), test_path, len(test_sentences)))
 
 
 def main() -> None:
   args = parse_args()
-  source_dir = args.source_dir
-  outfile = args.outfile
-  granularity = args.granularity
-  html_dir = os.path.join(source_dir, 'html')
-  with open(outfile, 'w') as f:
-    for file in sorted(os.listdir(html_dir)):
-      if file[-11:] != '-morph.html':
-        continue
-      parser = KNBCHTMLParser(granularity)
-      data = open(os.path.join(html_dir, file)).read()
-      parser.feed(data)
-      chunks = parser.chunks
-      chunks = postprocess(chunks)
-      if len(chunks) < 2:
-        continue
-      f.write(utils.SEP.join(chunks) + '\n')
-  print('\033[92mTraining data is output to: %s\033[0m' % (outfile))
+  process_knbc(
+      source_dir=args.source_dir,
+      outfile=args.outfile,
+      granularity=args.granularity,
+      split_dir=args.split_dir,
+      val_ratio=args.val_ratio,
+      test_ratio=args.test_ratio,
+      seed=args.seed,
+  )
 
 
 if __name__ == '__main__':

--- a/scripts/tests/test_pipeline_retraining.py
+++ b/scripts/tests/test_pipeline_retraining.py
@@ -26,6 +26,10 @@ from unittest.mock import patch
 LIB_PATH = os.path.join(os.path.dirname(__file__), '..', '..')
 sys.path.insert(0, os.path.abspath(LIB_PATH))
 
+import pytest
+
+pytest.importorskip("jax")
+
 import budoux  # noqa: E402
 from scripts import pipeline_retraining  # noqa: E402
 

--- a/scripts/tests/test_pipeline_retraining.py
+++ b/scripts/tests/test_pipeline_retraining.py
@@ -22,11 +22,11 @@ import unittest
 from typing import Any, Dict
 from unittest.mock import patch
 
+import pytest
+
 # Module hack to allow importing scripts and budoux from workspace root
 LIB_PATH = os.path.join(os.path.dirname(__file__), '..', '..')
 sys.path.insert(0, os.path.abspath(LIB_PATH))
-
-import pytest
 
 pytest.importorskip("jax")
 

--- a/scripts/tests/test_pipeline_retraining.py
+++ b/scripts/tests/test_pipeline_retraining.py
@@ -1,0 +1,225 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Test suite for deterministic model retraining meta-pipeline orchestrator."""
+
+import glob
+import json
+import os
+import sys
+import tempfile
+import unittest
+from typing import Any, Dict
+from unittest.mock import patch
+
+# Module hack to allow importing scripts and budoux from workspace root
+LIB_PATH = os.path.join(os.path.dirname(__file__), '..', '..')
+sys.path.insert(0, os.path.abspath(LIB_PATH))
+
+import budoux  # noqa: E402
+from scripts import pipeline_retraining  # noqa: E402
+
+SEP = budoux.utils.SEP
+
+
+class TestDeterministicSplitCorpus(unittest.TestCase):
+
+  def setUp(self) -> None:
+    self.temp_dir_obj = tempfile.TemporaryDirectory()
+    self.test_dir = self.temp_dir_obj.name
+
+  def tearDown(self) -> None:
+    self.temp_dir_obj.cleanup()
+
+  def test_deterministic_split_80_10_10(self) -> None:
+    src_path = os.path.join(self.test_dir, "src.txt")
+    lines = [f"line{i}" for i in range(100)]
+    with open(src_path, "w", encoding="utf-8") as f:
+      f.write("\n".join(lines) + "\n")
+
+    train_p, val_p, test_p = pipeline_retraining.deterministic_split_corpus(
+        source_path=src_path,
+        output_dir=self.test_dir,
+        lang="ja",
+        train_ratio=0.80,
+        val_ratio=0.10,
+        test_ratio=0.10,
+    )
+
+    with open(train_p, "r", encoding="utf-8") as f:
+      train_lines = [line_str.strip() for line_str in f if line_str.strip()]
+    with open(val_p, "r", encoding="utf-8") as f:
+      val_lines = [line_str.strip() for line_str in f if line_str.strip()]
+    with open(test_p, "r", encoding="utf-8") as f:
+      test_lines = [line_str.strip() for line_str in f if line_str.strip()]
+
+    self.assertEqual(len(train_lines), 80)
+    self.assertEqual(len(val_lines), 10)
+    self.assertEqual(len(test_lines), 10)
+    self.assertEqual(train_lines[0], "line42")
+    self.assertEqual(set(train_lines + val_lines + test_lines), set(lines))
+
+
+class TestMergeAndWeightTrainingSources(unittest.TestCase):
+
+  def setUp(self) -> None:
+    self.temp_dir_obj = tempfile.TemporaryDirectory()
+    self.test_dir = self.temp_dir_obj.name
+
+  def tearDown(self) -> None:
+    self.temp_dir_obj.cleanup()
+
+  @patch("os.path.dirname")
+  def test_merge_and_weight_training_sources(self, mock_dirname: Any) -> None:
+    mock_dirname.return_value = self.test_dir
+    base_train = os.path.join(self.test_dir, "knbc_train.txt")
+    with open(base_train, "w", encoding="utf-8") as f:
+      f.write(f"今日{SEP}は{SEP}天気\n")
+
+    lang_dir = os.path.join(self.test_dir, "..", "data", "finetuning", "ja")
+    os.makedirs(lang_dir, exist_ok=True)
+    for p in glob.glob(os.path.join(lang_dir, "*.txt")):
+      if os.path.isfile(p):
+        os.remove(p)
+
+    curated_path = os.path.join(lang_dir, "history.txt")
+    with open(curated_path, "w", encoding="utf-8") as f:
+      f.write(f"いよいよ{SEP}決戦\n")
+
+    out_path = os.path.join(self.test_dir, "weighted.txt")
+    pipeline_retraining.merge_and_weight_training_sources(
+        lang="ja",
+        output_path=out_path,
+        base_train_path=base_train,
+        base_scale=1,
+        curated_scale=10,
+    )
+
+    with open(out_path, "r", encoding="utf-8") as f:
+      lines = [line_str.strip() for line_str in f if line_str.strip()]
+
+    # base 1 line * 1 + curated 1 line * 10 = 11 lines
+    self.assertEqual(len(lines), 11)
+
+
+class TestRunBuildCompactModelStep(unittest.TestCase):
+
+  def setUp(self) -> None:
+    self.temp_dir_obj = tempfile.TemporaryDirectory()
+    self.test_dir = self.temp_dir_obj.name
+
+  def tearDown(self) -> None:
+    self.temp_dir_obj.cleanup()
+
+  def test_run_build_compact_model_step(self) -> None:
+    weights_p = os.path.join(self.test_dir, "weights.txt")
+    with open(weights_p, "w", encoding="utf-8") as f:
+      f.write("UW1:a\t1.5\n")
+
+    out_json = os.path.join(self.test_dir, "model.json")
+    model_dict = pipeline_retraining.run_build_compact_model_step(
+        weights_path=weights_p, model_json_out_path=out_json, scale=1000)
+    self.assertIn("UW1", model_dict)
+    with open(out_json, "r", encoding="utf-8") as f:
+      raw = f.read()
+    # verify compact separators (no whitespace after comma or colon)
+    self.assertIn('"UW1":{"a":', raw)
+
+
+class TestRunEvaluationReport(unittest.TestCase):
+
+  @patch("scripts.evaluate_model.evaluate")
+  def test_run_evaluation_report(self, mock_eval: Any) -> None:
+    mock_eval.return_value = {"accuracy": 0.99, "fscore": 0.98}
+    with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as m:
+      model_p = m.name
+    with tempfile.NamedTemporaryFile(suffix=".txt", delete=False) as h:
+      holdout_p = h.name
+
+    try:
+      reports = pipeline_retraining.run_evaluation_report(
+          model_path=model_p, holdout_test_path=holdout_p)
+      self.assertIn("holdout", reports)
+      self.assertEqual(reports["holdout"]["accuracy"], 0.99)
+    finally:
+      if os.path.exists(model_p):
+        os.remove(model_p)
+      if os.path.exists(holdout_p):
+        os.remove(holdout_p)
+
+
+class TestRunRetrainingPipeline(unittest.TestCase):
+
+  def setUp(self) -> None:
+    self.temp_dir_obj = tempfile.TemporaryDirectory()
+    self.test_dir = self.temp_dir_obj.name
+
+  def tearDown(self) -> None:
+    self.temp_dir_obj.cleanup()
+
+  @patch("scripts.pipeline_retraining.ensure_base_datasets")
+  @patch("scripts.pipeline_retraining.run_encode_step")
+  @patch("scripts.pipeline_retraining.run_find_conflicts_step")
+  @patch("scripts.pipeline_retraining.run_train_step")
+  @patch("scripts.pipeline_retraining.run_build_compact_model_step")
+  @patch("scripts.pipeline_retraining.run_evaluation_report")
+  def test_run_retraining_pipeline_end_to_end(
+      self,
+      mock_eval: Any,
+      mock_build: Any,
+      mock_train: Any,
+      mock_conflicts: Any,
+      mock_encode: Any,
+      mock_ensure: Any,
+  ) -> None:
+    train_p = os.path.join(self.test_dir, "train.txt")
+    val_p = os.path.join(self.test_dir, "val.txt")
+    test_p = os.path.join(self.test_dir, "test.txt")
+    for p in (train_p, val_p, test_p):
+      with open(p, "w", encoding="utf-8") as f:
+        f.write("sample\n")
+
+    mock_ensure.return_value = (train_p, val_p, test_p)
+
+    def side_effect_build(weights_path: str,
+                          model_json_out_path: str,
+                          scale: int = 1000) -> Dict[str, Any]:
+      res = {"UW1": {"a": 1000}}
+      with open(model_json_out_path, "w", encoding="utf-8") as f:
+        json.dump(res, f)
+      return res
+
+    mock_build.side_effect = side_effect_build
+    mock_eval.return_value = {
+        "holdout": {
+            "accuracy": 0.99
+        },
+        "regression": {
+            "accuracy": 1.0
+        },
+    }
+
+    out_model = os.path.join(self.test_dir, "ja.json")
+    res = pipeline_retraining.run_retraining_pipeline(
+        lang="ja",
+        iterations=10,
+        output_model=out_model,
+        regression_tsv_path=test_p,
+    )
+
+    self.assertEqual(res["status"], "completed")
+    self.assertTrue(os.path.exists(out_model))
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/scripts/tests/test_pipeline_synthesis.py
+++ b/scripts/tests/test_pipeline_synthesis.py
@@ -20,11 +20,11 @@ import unittest
 from typing import Any
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 # Module hack to allow importing scripts and budoux from workspace root
 LIB_PATH = os.path.join(os.path.dirname(__file__), '..', '..')
 sys.path.insert(0, os.path.abspath(LIB_PATH))
-
-import pytest
 
 pytest.importorskip("google.genai")
 

--- a/scripts/tests/test_pipeline_synthesis.py
+++ b/scripts/tests/test_pipeline_synthesis.py
@@ -1,0 +1,148 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Test suite for data synthesis meta-pipeline orchestrator."""
+
+import os
+import sys
+import tempfile
+import unittest
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+# Module hack to allow importing scripts and budoux from workspace root
+LIB_PATH = os.path.join(os.path.dirname(__file__), '..', '..')
+sys.path.insert(0, os.path.abspath(LIB_PATH))
+
+import budoux  # noqa: E402
+from scripts import pipeline_synthesis  # noqa: E402
+
+SEP = budoux.utils.SEP
+
+
+class TestHumanSampleReviewGate(unittest.TestCase):
+
+  def test_human_sample_review_gate_auto_accept(self) -> None:
+    lines = [f"いよいよ{SEP}はじまる決戦だ。"]
+    result = pipeline_synthesis.human_sample_review_gate(
+        lines, auto_accept=True)
+    self.assertEqual(result, lines)
+
+  def test_human_sample_review_gate_manual_accept(self) -> None:
+    lines = [f"いよいよ{SEP}はじまる決戦だ。"]
+    mock_input = MagicMock(return_value="y")
+    result = pipeline_synthesis.human_sample_review_gate(
+        lines, auto_accept=False, input_func=mock_input)
+    self.assertEqual(result, lines)
+
+  def test_human_sample_review_gate_manual_reject(self) -> None:
+    lines = [f"いよいよ{SEP}はじまる決戦だ。"]
+    mock_input = MagicMock(return_value="n")
+    result = pipeline_synthesis.human_sample_review_gate(
+        lines, auto_accept=False, input_func=mock_input)
+    self.assertEqual(result, [])
+
+
+class TestRegisterSyntheticDataset(unittest.TestCase):
+
+  def setUp(self) -> None:
+    self.temp_dir_obj = tempfile.TemporaryDirectory()
+    self.test_dir = self.temp_dir_obj.name
+
+  def tearDown(self) -> None:
+    self.temp_dir_obj.cleanup()
+
+  @patch("os.path.dirname")
+  def test_register_synthetic_dataset(self, mock_dirname: Any) -> None:
+    mock_dirname.return_value = self.test_dir
+    lines = [f"いよいよ{SEP}はじまる決戦だ。"]
+    issue_path = pipeline_synthesis.register_synthetic_dataset(
+        lang="ja",
+        issue_id="468",
+        approved_lines=lines,
+    )
+    self.assertTrue(os.path.exists(issue_path))
+
+
+class TestAppendToQualitySuiteAndHistory(unittest.TestCase):
+
+  def setUp(self) -> None:
+    self.temp_dir_obj = tempfile.TemporaryDirectory()
+    self.test_dir = self.temp_dir_obj.name
+    self.quality_path = os.path.join(self.test_dir, "ja.tsv")
+    self.history_path = os.path.join(self.test_dir, "history.txt")
+    with open(self.quality_path, "w", encoding="utf-8") as f:
+      f.write("init\tテストです。\n")
+
+  def tearDown(self) -> None:
+    self.temp_dir_obj.cleanup()
+
+  def test_append_to_quality_suite(self) -> None:
+    sample = f"いよいよ{SEP}はじまる決戦だ。"
+    pipeline_synthesis.append_to_quality_suite(
+        lang="ja",
+        issue_id="468",
+        sample_line=sample,
+        quality_path=self.quality_path,
+    )
+    with open(self.quality_path, "r", encoding="utf-8") as f:
+      content = f.read()
+    self.assertIn("gh468", content)
+
+  def test_append_to_history(self) -> None:
+    samples = [f"いよいよ{SEP}はじまる決戦だ。"]
+    pipeline_synthesis.append_to_history(
+        lang="ja",
+        approved_lines=samples,
+        history_path=self.history_path,
+    )
+    with open(self.history_path, "r", encoding="utf-8") as f:
+      content = f.read()
+    self.assertIn("いよいよ", content)
+
+
+class TestRunSynthesisPipeline(unittest.TestCase):
+
+  def setUp(self) -> None:
+    self.temp_dir_obj = tempfile.TemporaryDirectory()
+    self.test_dir = self.temp_dir_obj.name
+
+  def tearDown(self) -> None:
+    self.temp_dir_obj.cleanup()
+
+  @patch("scripts.synthesize_samples.run_agentic_synthesis_pipeline")
+  @patch("scripts.pipeline_synthesis.register_synthetic_dataset")
+  def test_run_synthesis_pipeline_end_to_end(self, mock_register: Any,
+                                             mock_synth: Any) -> None:
+    raw_sentence = f"いよいよ{SEP}はじまる決戦だ。"
+    mock_synth.return_value = [raw_sentence]
+    mock_register.return_value = os.path.join(self.test_dir, "issue_468.txt")
+
+    quality_path = os.path.join(self.test_dir, "ja.tsv")
+    history_path = os.path.join(self.test_dir, "history.txt")
+    with open(quality_path, "w", encoding="utf-8") as f:
+      f.write("init\tテスト\n")
+
+    res = pipeline_synthesis.run_synthesis_pipeline(
+        inputs=["いよいよ/はじまる"],
+        lang="ja",
+        auto_accept=True,
+        quality_path=quality_path,
+        history_path=history_path,
+    )
+    self.assertEqual(res["status"], "completed")
+    self.assertEqual(res["approved_lines_count"], 1)
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/scripts/tests/test_pipeline_synthesis.py
+++ b/scripts/tests/test_pipeline_synthesis.py
@@ -24,6 +24,10 @@ from unittest.mock import MagicMock, patch
 LIB_PATH = os.path.join(os.path.dirname(__file__), '..', '..')
 sys.path.insert(0, os.path.abspath(LIB_PATH))
 
+import pytest
+
+pytest.importorskip("google.genai")
+
 import budoux  # noqa: E402
 from scripts import pipeline_synthesis  # noqa: E402
 

--- a/scripts/tests/test_prepare_knbc.py
+++ b/scripts/tests/test_prepare_knbc.py
@@ -75,3 +75,31 @@ class TestKNBCHTMLParser(unittest.TestCase):
     parser = prepare_knbc.KNBCHTMLParser('word')
     parser.feed(self.example_html)
     self.assertListEqual(parser.chunks, ['abc', 'de', 'fgh', 'ijkl', 'mn'])
+
+
+class TestMainSplit(unittest.TestCase):
+
+  def test_main_split(self) -> None:
+    import tempfile
+    with tempfile.TemporaryDirectory() as tmp_dir:
+      html_dir = os.path.join(tmp_dir, 'html')
+      os.makedirs(html_dir, exist_ok=True)
+      with open(os.path.join(html_dir, 'sample-morph.html'), 'w') as f:
+        f.write(TestKNBCHTMLParser.example_html)
+
+      out_file = os.path.join(tmp_dir, 'source_knbc.txt')
+      split_dir = os.path.join(tmp_dir, 'splits')
+
+      sys_argv_orig = sys.argv
+      try:
+        sys.argv = [
+            'prepare_knbc.py', tmp_dir, '-o', out_file, '--split-dir', split_dir
+        ]
+        prepare_knbc.main()
+      finally:
+        sys.argv = sys_argv_orig
+
+      self.assertTrue(os.path.exists(out_file))
+      self.assertTrue(os.path.exists(os.path.join(split_dir, 'knbc_train.txt')))
+      self.assertTrue(os.path.exists(os.path.join(split_dir, 'knbc_val.txt')))
+      self.assertTrue(os.path.exists(os.path.join(split_dir, 'knbc_test.txt')))

--- a/scripts/tests/test_synthesize_samples.py
+++ b/scripts/tests/test_synthesize_samples.py
@@ -20,11 +20,11 @@ import unittest
 from typing import Any
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 # Module hack to allow importing scripts and budoux from workspace root
 LIB_PATH = os.path.join(os.path.dirname(__file__), '..', '..')
 sys.path.insert(0, os.path.abspath(LIB_PATH))
-
-import pytest
 
 pytest.importorskip("google.genai")
 

--- a/scripts/tests/test_synthesize_samples.py
+++ b/scripts/tests/test_synthesize_samples.py
@@ -24,6 +24,10 @@ from unittest.mock import MagicMock, patch
 LIB_PATH = os.path.join(os.path.dirname(__file__), '..', '..')
 sys.path.insert(0, os.path.abspath(LIB_PATH))
 
+import pytest
+
+pytest.importorskip("google.genai")
+
 import budoux  # noqa: E402
 from scripts import synthesize_samples  # noqa: E402
 


### PR DESCRIPTION
- Introduce scripts/pipeline_synthesis.py for interactive LLM synthetic sample generation, review gates, and curated storage saving
- Introduce scripts/pipeline_retraining.py for deterministic 80:10:10 KNBC split, separated weighted encoding (scale 100 for data/finetuning/{lang}/*.txt), AdaBoost training, and comparative reporting
- Add unit test suites scripts/tests/test_pipeline_synthesis.py and scripts/tests/test_pipeline_retraining.py
- Support deterministic 3-way split in scripts/prepare_knbc.py (--split-dir)
- Update documentation in scripts/README.md

TAG=agy
CONV=af16f8d5-a8c2-4260-82a9-9617e2ba2480