### PR TITLE
refactor(scripts): add end-to-end training pipeline

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -269,7 +269,8 @@ can tune, and they are what we call *weights*.
 A good nature of this algorithm is that it iteratively updates the weights from
 the most important features to the least ones.
 The training script appends the weight diffs to the output file, which is
-specified by the `-o` / `--output` arg, at a frequency specified by the `--out-span` arg.
+specified by the `-o` / `--output` arg, at a frequency specified by the
+`--out-span` arg.
 Hence, you can build a model file from the output weight file even if you needed
 to interrupt the program before it ends (cf. [Anytime algorithm](https://en.wikipedia.org/wiki/Anytime_algorithm)).
 
@@ -429,6 +430,7 @@ To remediate a model defect reported in a GitHub issue (e.g., Issue #468):
 
 1. **Synthesize Candidate Sentences:**
    Generate candidate training sentences into a staging file:
+
    ```bash
    python scripts/synthesize_samples.py --issue=468 --lang=ja --output=staging_468.txt
    ```
@@ -441,6 +443,7 @@ To remediate a model defect reported in a GitHub issue (e.g., Issue #468):
 
 3. **Save to Fine-Tuning Corpus:**
    Save the reviewed file into `data/finetuning/ja/issue_468.txt`:
+
    ```bash
    mkdir -p data/finetuning/ja
    cp staging_468.txt data/finetuning/ja/issue_468.txt
@@ -450,7 +453,7 @@ To remediate a model defect reported in a GitHub issue (e.g., Issue #468):
    Execute `run_training_pipeline.py`. It automatically merges all datasets
    under `data/finetuning/ja/*.txt` (with 100x weighting), retrains the JAX
    model, and verifies quality benchmarks:
+
    ```bash
    python scripts/run_training_pipeline.py --lang=ja --iter=200000 --split-dir=tmp/splits
    ```
-

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -408,13 +408,16 @@ BudouX segmentation models.
 
 ### End-to-End Retraining & Data Synthesis
 
-To automate dataset partitioning (80:10:10 train/val/test splits), oversampled fine-tuning data merging, JAX model fitting, and holdout quality benchmarking, run:
+To automate dataset partitioning (80:10:10 train/val/test splits), oversampled
+fine-tuning data merging, JAX model fitting, and holdout quality benchmarking,
+run:
 
 ```bash
 python scripts/run_training_pipeline.py --lang=ja --iter=200000 --split-dir=tmp/splits
 ```
 
-To synthesize bug-fix training samples from GitHub issue reports and persist them directly to fine-tuning datasets and quality benchmarks:
+To synthesize bug-fix training samples from GitHub issue reports and persist
+them directly to fine-tuning datasets and quality benchmarks:
 
 ```bash
 python scripts/synthesize_samples.py --issue=123 --save-dataset --append-quality
@@ -444,7 +447,9 @@ To remediate a model defect reported in a GitHub issue (e.g., Issue #468):
    ```
 
 4. **Run Retraining Pipeline:**
-   Execute `run_training_pipeline.py`. It automatically merges all datasets under `data/finetuning/ja/*.txt` (with 100x weighting), retrains the JAX model, and verifies quality benchmarks:
+   Execute `run_training_pipeline.py`. It automatically merges all datasets
+   under `data/finetuning/ja/*.txt` (with 100x weighting), retrains the JAX
+   model, and verifies quality benchmarks:
    ```bash
    python scripts/run_training_pipeline.py --lang=ja --iter=200000 --split-dir=tmp/splits
    ```

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -2,20 +2,71 @@
 
 This directory is a collection of scripts to generate BudouX model files.
 The figure below provides an overview of how each script transforms data files,
-from corpora to machine learning models.
+from corpora and synthetic sample generation to compiled machine learning models.
 
 ```mermaid
-flowchart
-    corpus[(Corpus)] --> prepare[prepare_*.py]
-    prepare --> source[\Source text file\]
-    source --> encode[encode_data.py]
-    encode --> encoded[\Encoded data file\]
-    encoded --> train[train.py]
-    train --> weights[\Weight file\]
-    weights --> build[build_model.py]
-    build --> model[\Model file - JSON\]
-    model --> translate[translate_model.py]
-    translate --> modelx[\Model file - Other formats\]
+flowchart TB
+    %% Phase 1: External KNBC Corpus Preparation
+    subgraph P1 ["1. KNBC External Corpus Preparation"]
+        direction TB
+        KNBC_RAW["curl Download<br>KNBC_v1.0_090925_utf8.tar.bz2"] --> KNBC_PREP["prepare_knbc.py"]
+        KNBC_PREP --> KNBC_SRC["source_knbc.txt<br>(Full Unsplit Corpus)"]
+        
+        KNBC_PREP -->|"80% Train Split (--split-dir)"| KNBC_TRAIN["knbc_train.txt"]
+        KNBC_PREP -->|"10% Val Split (--split-dir)"| KNBC_VAL["knbc_val.txt"]
+        KNBC_PREP -->|"10% Test Split (--split-dir)"| KNBC_TEST["knbc_test.txt<br>(Generalization Benchmark)"]
+    end
+
+    %% Phase 2: Agentic Synthetic Sample Generation
+    subgraph P2 ["2. Agentic Synthetic Sample Generation (synthesize_samples.py)"]
+        direction TB
+        CLI_IN["CLI Inputs: --issue=468<br>or --input='...'"] --> AGENT1["Agent 1: Intent Understanding"]
+        AGENT1 --> AGENT2["Agent 2: Example Generator"]
+        AGENT2 --> OVERLAY["Deterministic Alignment Utility"]
+        OVERLAY --> AGENT3["Agent 3: Linguistic Expert Polisher"]
+        AGENT3 --> OUTPUT_FLAGS["Output Persistence Flags<br>(--save-dataset / --append-quality)"]
+    end
+
+    %% Phase 3: Dataset & Test Suite Persistence
+    subgraph P3 ["3. Dataset & Quality Suite Persistence"]
+        direction TB
+        OUTPUT_FLAGS -->|"(--save-dataset)"| SYNTH_STORE["data/finetuning/ja/issue_*.txt<br>(Issue-specific Samples)"]
+        OUTPUT_FLAGS -->|"(--append-quality)"| REG_TSV["tests/quality/ja.tsv<br>(Canonical Test Suite)"]
+    end
+
+    %% Phase 4: Data Merging & Training Loop
+    subgraph P4 ["4. Data Merging & JAX Training Loop (run_training_pipeline.py)"]
+        direction TB
+        KNBC_TRAIN --> MERGE_DATA["Data Merging & Weighting<br>(1x base corpus, 100x fine-tuning samples)"]
+        SYNTH_STORE --> MERGE_DATA
+        
+        MERGE_DATA --> COMBINED_TXT["tmp/weighted_train.txt"]
+        COMBINED_TXT --> ENCODE_PY["Feature Encoding<br>(encode_data.py)"]
+        ENCODE_PY --> CONFLICT_PY["Conflict Resolution<br>(find_conflicts.py -t 0.8)"]
+        CONFLICT_PY --> TRAIN_PY["JAX AdaBoost Training<br>(train.py --iter=200000)"]
+        
+        TRAIN_PY --> BUILD_PY["Model Compilation<br>(build_model.py)"]
+    end
+
+    %% Phase 5: Unified QA & Output Artifacts
+    subgraph P5 ["5. Unified QA Benchmark & Output Model"]
+        direction TB
+        BUILD_PY --> TEMP_MODEL["budoux/models/ja.json"]
+        TEMP_MODEL --> EVAL_PY["Model Benchmark Evaluation<br>(evaluate_model.py)"]
+        
+        REG_TSV -->|"1. Quality Suite Regression Check"| EVAL_PY
+        KNBC_TEST -->|"2. Generalization F-score Measurement"| EVAL_PY
+        
+        EVAL_PY --> FINAL_JSON["budoux/models/ja.json<br>(Verified Production Model)"]
+    end
+
+    %% Direct Connections (Validation Feature Encoding)
+    KNBC_VAL -->|"encode_data.py"| VAL_ENCODED["tmp/val_encoded.txt"]
+    VAL_ENCODED -->|"Validation Loss Monitoring"| TRAIN_PY
+
+    %% Border Styles
+    style REG_TSV stroke-width:2px
+    style FINAL_JSON stroke-width:2px
 ```
 
 ## Preparing a source text
@@ -47,10 +98,13 @@ We picked these segmentations to provide a satisfactory reading experience in
 those languages, but you can apply another segmentation method that works best
 for your purpose when you build a custom model.
 
-You can make a source data file by hand or running data preparation scripts (`prepare_*.py`)
-that extracts segmented sentences from a corpus.
-Currently, this directory has one data preparation script, [`prepare_knbc.py`](https://github.com/google/budoux/tree/main/scripts/prepare_knbc.py),
-which generates a source text file from [Kyoto University and NTT Blog (KNBC) Corpus](https://nlp.ist.i.kyoto-u.ac.jp/kuntt/),
+You can make a source data file by hand or running data preparation scripts
+(`prepare_*.py`) that extracts segmented sentences from a corpus.
+Currently, this directory provides data preparation scripts such as
+[`prepare_knbc.py`](https://github.com/google/budoux/tree/main/scripts/prepare_knbc.py)
+and [`prepare_wisesight.py`](https://github.com/google/budoux/tree/main/scripts/prepare_wisesight.py).
+For Japanese, `prepare_knbc.py` generates a source text file from
+[Kyoto University and NTT Blog (KNBC) Corpus](https://nlp.ist.i.kyoto-u.ac.jp/kuntt/),
 which segments Japanese sentences by phrase.
 When we support other corpora as data sources, we should add the data
 preparation scripts for them in this directory with the `prepare_` prefix.
@@ -215,7 +269,7 @@ can tune, and they are what we call *weights*.
 A good nature of this algorithm is that it iteratively updates the weights from
 the most important features to the least ones.
 The training script appends the weight diffs to the output file, which is
-specified by the `--out` arg, at a frequency specified by the `--out-span` arg.
+specified by the `-o` / `--output` arg, at a frequency specified by the `--out-span` arg.
 Hence, you can build a model file from the output weight file even if you needed
 to interrupt the program before it ends (cf. [Anytime algorithm](https://en.wikipedia.org/wiki/Anytime_algorithm)).
 
@@ -304,7 +358,7 @@ Notice that the features are separated between the colon mark, and the latters
 are grouped by the former.
 The scores are summed up if there are multiple items that belong to the same group.
 Also, the scores are scaled and round to integers.
-We apply these conversations to make the output model file smaller and the
+We apply these conversions to make the output model file smaller and the
 inference faster.
 
 The keys in the first layer (e.g. `UW1` and `UW2`) are the feature types that
@@ -323,7 +377,7 @@ python scripts/build_model.py weights.txt -o model.json
 
 JSON is the primary format for the BudouX models, but some libraries (e.g. [ICU](https://icu.unicode.org/))
 may want to use another serialization format to store  model data.
-You can translate a model JSON file to another format with [`translate.py`](https://github.com/google/budoux/tree/main/scripts/translate.py)
+You can translate a model JSON file to another format with [`translate_model.py`](https://github.com/google/budoux/tree/main/scripts/translate_model.py)
 if it's more useful for your specific purpose.
 For example, you can convert a model file to an ICU Resource Bundle by running:
 
@@ -339,7 +393,7 @@ When a model file misclassifies character transition boundaries in specific edge
 cases (for example, missing phrase segmentations across newly observed character
 combinations), resolving the discrepancy requires performing full AdaBoost
 linear retraining using `train.py` across updated feature records
-(`encoded_data.txt`).
+(`encoded.txt`).
 
 Historically, partial gradient-descent fine-tuning over established base JSON
 models (`finetune.py`) was supported. However, because partial fine-tuning
@@ -351,3 +405,47 @@ Therefore, full AdaBoost model optimization via `train.py` paired with
 statistical conflict resolution (`find_conflicts.py -t 0.8`) and model building
 (`build_model.py`) is the sole canonical methodology for updating and tuning
 BudouX segmentation models.
+
+### End-to-End Retraining & Data Synthesis
+
+To automate dataset partitioning (80:10:10 train/val/test splits), oversampled fine-tuning data merging, JAX model fitting, and holdout quality benchmarking, run:
+
+```bash
+python scripts/run_training_pipeline.py --lang=ja --iter=200000 --split-dir=tmp/splits
+```
+
+To synthesize bug-fix training samples from GitHub issue reports and persist them directly to fine-tuning datasets and quality benchmarks:
+
+```bash
+python scripts/synthesize_samples.py --issue=123 --save-dataset --append-quality
+```
+
+### Typical Workflow: Synthesizing, Editing, and Retraining
+
+To remediate a model defect reported in a GitHub issue (e.g., Issue #468):
+
+1. **Synthesize Candidate Sentences:**
+   Generate candidate training sentences into a staging file:
+   ```bash
+   python scripts/synthesize_samples.py --issue=468 --lang=ja --output=staging_468.txt
+   ```
+
+2. **Review and Edit Candidates:**
+   Open `staging_468.txt` in a text editor to:
+   - Remove any unsatisfactory candidate lines.
+   - Adjust `▁` (U+2581) phrase boundary markers where needed.
+   - Add custom sentences if desired.
+
+3. **Save to Fine-Tuning Corpus:**
+   Save the reviewed file into `data/finetuning/ja/issue_468.txt`:
+   ```bash
+   mkdir -p data/finetuning/ja
+   cp staging_468.txt data/finetuning/ja/issue_468.txt
+   ```
+
+4. **Run Retraining Pipeline:**
+   Execute `run_training_pipeline.py`. It automatically merges all datasets under `data/finetuning/ja/*.txt` (with 100x weighting), retrains the JAX model, and verifies quality benchmarks:
+   ```bash
+   python scripts/run_training_pipeline.py --lang=ja --iter=200000 --split-dir=tmp/splits
+   ```
+

--- a/scripts/prepare_knbc.py
+++ b/scripts/prepare_knbc.py
@@ -26,9 +26,10 @@ $ python scripts/prepare_knbc.py KNBC_v1.0_090925_utf8 -o source_knbc.txt
 
 import argparse
 import os
+import random
 import sys
-import typing
 from html.parser import HTMLParser
+from typing import Literal, Optional
 
 # module hack
 LIB_PATH = os.path.join(os.path.dirname(__file__), '..')
@@ -37,7 +38,7 @@ sys.path.insert(0, os.path.abspath(LIB_PATH))
 from budoux import utils  # noqa (module hack)
 
 GRANULARITY_OPTIONS = {'phrase', 'tag', 'word'}
-Granularity = typing.Literal['phrase', 'tag', 'word']
+Granularity = Literal['phrase', 'tag', 'word']
 
 
 class KNBCHTMLParser(HTMLParser):
@@ -71,7 +72,7 @@ class KNBCHTMLParser(HTMLParser):
 
   def handle_starttag(
       self, tag: str,
-      attributes: typing.List[typing.Tuple[str, typing.Optional[str]]]) -> None:
+      attributes: list[tuple[str, Optional[str]]]) -> None:
     if tag == 'tr':
       self.row += 1
       self.col = 0
@@ -103,8 +104,8 @@ class KNBCHTMLParser(HTMLParser):
       self.current_word = data
 
 
-def break_before_sequence(chunks: typing.List[str],
-                          sequence: str) -> typing.List[str]:
+def break_before_sequence(chunks: list[str],
+                          sequence: str) -> list[str]:
   """Breaks chunks before a specified character sequence appears.
 
   Args:
@@ -120,7 +121,7 @@ def break_before_sequence(chunks: typing.List[str],
   return chunks
 
 
-def postprocess(chunks: typing.List[str]) -> typing.List[str]:
+def postprocess(chunks: list[str]) -> list[str]:
   """Applies some processes to modify the extracted chunks.
 
   Args:
@@ -160,28 +161,107 @@ word: 携帯 / ユーザー / の / 仲間 / 入り / を / する / か / で�
 ''',
       choices=GRANULARITY_OPTIONS,
       default=DEFAULT_GRANULARITY)
+  parser.add_argument(
+      '--split-dir',
+      help='Directory to output 3-way split datasets (knbc_train.txt, knbc_val.txt, knbc_test.txt).',
+      default=None)
+  parser.add_argument(
+      '--val-ratio',
+      type=float,
+      help='Ratio of validation partition (default: 0.10).',
+      default=0.10)
+  parser.add_argument(
+      '--test-ratio',
+      type=float,
+      help='Ratio of test partition (default: 0.10).',
+      default=0.10)
+  parser.add_argument(
+      '--seed',
+      type=int,
+      help='Random seed for deterministic split (default: 42).',
+      default=42)
   return parser.parse_args()
+
+
+def process_knbc(
+    source_dir: str,
+    outfile: str,
+    granularity: Granularity = 'phrase',
+    split_dir: Optional[str] = None,
+    val_ratio: float = 0.10,
+    test_ratio: float = 0.10,
+    seed: int = 42,
+) -> None:
+  """Processes KNBC HTML archives into segmented text files and optional splits."""
+  html_dir = os.path.join(source_dir, 'html')
+  sentences: list[str] = []
+  for file in sorted(os.listdir(html_dir)):
+    if file[-11:] != '-morph.html':
+      continue
+    parser = KNBCHTMLParser(granularity)
+    data = open(os.path.join(html_dir, file)).read()
+    parser.feed(data)
+    chunks = parser.chunks
+    chunks = postprocess(chunks)
+    if len(chunks) < 2:
+      continue
+    sentences.append(utils.SEP.join(chunks))
+
+  with open(outfile, 'w', encoding='utf-8') as f:
+    for s in sentences:
+      f.write(s + '\n')
+  print('\033[92mFull training data is output to: %s\033[0m' % (outfile))
+
+  if split_dir:
+    valid_ratios = (0.0 <= val_ratio <= 1.0) and (
+        0.0 <= test_ratio <= 1.0) and (val_ratio + test_ratio < 1.0)
+    if not valid_ratios:
+      raise ValueError(
+          "Invalid split ratios: val_ratio + test_ratio must be less than 1.0.")
+    os.makedirs(split_dir, exist_ok=True)
+    shuffled = sentences.copy()
+    random.seed(seed)
+    random.shuffle(shuffled)
+
+    num_total = len(shuffled)
+    num_val = int(num_total * val_ratio)
+    num_test = int(num_total * test_ratio)
+    num_train = num_total - num_val - num_test
+
+    train_sentences = shuffled[:num_train]
+    val_sentences = shuffled[num_train:num_train + num_val]
+    test_sentences = shuffled[num_train + num_val:]
+
+    train_path = os.path.join(split_dir, 'knbc_train.txt')
+    val_path = os.path.join(split_dir, 'knbc_val.txt')
+    test_path = os.path.join(split_dir, 'knbc_test.txt')
+
+    for path, split_lines in [
+        (train_path, train_sentences),
+        (val_path, val_sentences),
+        (test_path, test_sentences),
+    ]:
+      with open(path, 'w', encoding='utf-8') as f:
+        for line in split_lines:
+          f.write(line + '\n')
+
+    print(
+        '\033[92m3-Way split dataset written to %s:\n  Train: %s (%d lines)\n  Val:   %s (%d lines)\n  Test:  %s (%d lines)\033[0m'
+        % (split_dir, train_path, len(train_sentences), val_path,
+           len(val_sentences), test_path, len(test_sentences)))
 
 
 def main() -> None:
   args = parse_args()
-  source_dir = args.source_dir
-  outfile = args.outfile
-  granularity = args.granularity
-  html_dir = os.path.join(source_dir, 'html')
-  with open(outfile, 'w') as f:
-    for file in sorted(os.listdir(html_dir)):
-      if file[-11:] != '-morph.html':
-        continue
-      parser = KNBCHTMLParser(granularity)
-      data = open(os.path.join(html_dir, file)).read()
-      parser.feed(data)
-      chunks = parser.chunks
-      chunks = postprocess(chunks)
-      if len(chunks) < 2:
-        continue
-      f.write(utils.SEP.join(chunks) + '\n')
-  print('\033[92mTraining data is output to: %s\033[0m' % (outfile))
+  process_knbc(
+      source_dir=args.source_dir,
+      outfile=args.outfile,
+      granularity=args.granularity,
+      split_dir=args.split_dir,
+      val_ratio=args.val_ratio,
+      test_ratio=args.test_ratio,
+      seed=args.seed,
+  )
 
 
 if __name__ == '__main__':

--- a/scripts/prepare_knbc.py
+++ b/scripts/prepare_knbc.py
@@ -70,9 +70,8 @@ class KNBCHTMLParser(HTMLParser):
     self.on_split_row = False
     self.granularity = granularity
 
-  def handle_starttag(
-      self, tag: str,
-      attributes: list[tuple[str, Optional[str]]]) -> None:
+  def handle_starttag(self, tag: str,
+                      attributes: list[tuple[str, Optional[str]]]) -> None:
     if tag == 'tr':
       self.row += 1
       self.col = 0
@@ -104,8 +103,7 @@ class KNBCHTMLParser(HTMLParser):
       self.current_word = data
 
 
-def break_before_sequence(chunks: list[str],
-                          sequence: str) -> list[str]:
+def break_before_sequence(chunks: list[str], sequence: str) -> list[str]:
   """Breaks chunks before a specified character sequence appears.
 
   Args:

--- a/scripts/run_training_pipeline.py
+++ b/scripts/run_training_pipeline.py
@@ -90,7 +90,10 @@ def run_retraining_pipeline(
 
     print("[Encode] Encoding feature boundaries...")
     subprocess.run(
-        [sys.executable, "scripts/encode_data.py", weighted_train, "-o", encoded_train],
+        [
+            sys.executable, "scripts/encode_data.py", weighted_train, "-o",
+            encoded_train
+        ],
         check=True,
     )
 
@@ -111,7 +114,10 @@ def run_retraining_pipeline(
     val_split = os.path.join(split_dir, "knbc_val.txt")
     if os.path.exists(val_split):
       subprocess.run(
-          [sys.executable, "scripts/encode_data.py", val_split, "-o", val_encoded],
+          [
+              sys.executable, "scripts/encode_data.py", val_split, "-o",
+              val_encoded
+          ],
           check=True,
       )
 
@@ -133,7 +139,10 @@ def run_retraining_pipeline(
 
     print(f"[Export] Exporting compact JSON model to {out_model}...")
     subprocess.run(
-        [sys.executable, "scripts/build_model.py", weights_path, "-o", out_model],
+        [
+            sys.executable, "scripts/build_model.py", weights_path, "-o",
+            out_model
+        ],
         check=True,
     )
 
@@ -170,11 +179,9 @@ def run_retraining_pipeline(
 
 def main() -> None:
   parser = argparse.ArgumentParser(
-      description="Streamlined retraining meta-pipeline for BudouX models."
-  )
+      description="Streamlined retraining meta-pipeline for BudouX models.")
   parser.add_argument(
-      "--lang", type=str, default="ja", help="Language code (default: ja)"
-  )
+      "--lang", type=str, default="ja", help="Language code (default: ja)")
   parser.add_argument(
       "--iter",
       type=int,

--- a/scripts/run_training_pipeline.py
+++ b/scripts/run_training_pipeline.py
@@ -1,0 +1,206 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Streamlined retraining meta-pipeline for BudouX models."""
+
+import argparse
+import glob
+import os
+import shutil
+import subprocess
+import sys
+import tarfile
+import tempfile
+import urllib.request
+
+LIB_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, LIB_PATH)
+
+KNBC_URL = "https://nlp.ist.i.kyoto-u.ac.jp/kuntt/KNBC_v1.0_090925_utf8.tar.bz2"
+
+
+def run_retraining_pipeline(
+    lang: str = "ja",
+    iterations: int = 200000,
+    split_dir: str = "tmp/splits",
+    out_model: str = "",
+    weight_factor: int = 100,
+) -> None:
+  """Executes end-to-end dataset preparation, JAX fitting, and validation."""
+  if not out_model:
+    out_model = os.path.join("budoux", "models", f"{lang}.json")
+
+  train_file = os.path.join(split_dir, "knbc_train.txt")
+  if os.path.exists(train_file):
+    print(f"[Dataset] Using existing KNBC dataset splits in {split_dir}.")
+  else:
+    print(f"[Dataset] Fetching KNBC corpus from {KNBC_URL}...")
+    with tempfile.TemporaryDirectory() as tmp_knbc:
+      tar_path = os.path.join(tmp_knbc, "knbc.tar.bz2")
+      urllib.request.urlretrieve(KNBC_URL, tar_path)
+      with tarfile.open(tar_path, "r:bz2") as tar:
+        tar.extractall(path=tmp_knbc)
+      source_dir = os.path.join(tmp_knbc, "KNBC_v1.0_090925_utf8")
+      outfile = os.path.join(tmp_knbc, "source_knbc.txt")
+      subprocess.run(
+          [
+              sys.executable,
+              "scripts/prepare_knbc.py",
+              source_dir,
+              "-o",
+              outfile,
+              "--split-dir",
+              split_dir,
+          ],
+          check=True,
+      )
+
+  with tempfile.TemporaryDirectory() as tmp:
+    weighted_train = os.path.join(tmp, "weighted_train.txt")
+    finetuning_pattern = os.path.join("data", "finetuning", lang, "*.txt")
+
+    print(
+        f"[Merge] Combining fine-tuning data ({finetuning_pattern}) with {weight_factor}x weight..."
+    )
+    with open(weighted_train, "w", encoding="utf-8") as out_f:
+      for ft_file in sorted(glob.glob(finetuning_pattern)):
+        with open(ft_file, "r", encoding="utf-8") as in_f:
+          content = in_f.read()
+        for _ in range(weight_factor):
+          out_f.write(content)
+      knbc_train = os.path.join(split_dir, "knbc_train.txt")
+      if os.path.exists(knbc_train):
+        with open(knbc_train, "r", encoding="utf-8") as in_f:
+          shutil.copyfileobj(in_f, out_f)
+
+    encoded_train = os.path.join(tmp, "encoded.txt")
+    cleaned_train = os.path.join(tmp, "cleaned.txt")
+    val_encoded = os.path.join(tmp, "val_encoded.txt")
+    weights_path = os.path.join(tmp, "weights.txt")
+
+    print("[Encode] Encoding feature boundaries...")
+    subprocess.run(
+        [sys.executable, "scripts/encode_data.py", weighted_train, "-o", encoded_train],
+        check=True,
+    )
+
+    print("[Filter] Resolving conflict boundaries...")
+    subprocess.run(
+        [
+            sys.executable,
+            "scripts/find_conflicts.py",
+            encoded_train,
+            "-o",
+            cleaned_train,
+            "-t",
+            "0.8",
+        ],
+        check=True,
+    )
+
+    val_split = os.path.join(split_dir, "knbc_val.txt")
+    if os.path.exists(val_split):
+      subprocess.run(
+          [sys.executable, "scripts/encode_data.py", val_split, "-o", val_encoded],
+          check=True,
+      )
+
+    print(f"[Train] Fitting JAX model ({iterations} iterations)...")
+    train_cmd = [
+        sys.executable,
+        "scripts/train.py",
+        cleaned_train,
+        "-o",
+        weights_path,
+        "--iter",
+        str(iterations),
+        "--feature-thres",
+        "2",
+    ]
+    if os.path.exists(val_encoded):
+      train_cmd.extend(["--val-data", val_encoded])
+    subprocess.run(train_cmd, check=True)
+
+    print(f"[Export] Exporting compact JSON model to {out_model}...")
+    subprocess.run(
+        [sys.executable, "scripts/build_model.py", weights_path, "-o", out_model],
+        check=True,
+    )
+
+    print("[Evaluation] Evaluating quality suite benchmark...")
+    quality_file = os.path.join("tests", "quality", f"{lang}.tsv")
+    if os.path.exists(quality_file):
+      subprocess.run(
+          [
+              sys.executable,
+              "scripts/evaluate_model.py",
+              "-m",
+              out_model,
+              "-t",
+              quality_file,
+          ],
+          check=True,
+      )
+
+    test_split = os.path.join(split_dir, "knbc_test.txt")
+    if os.path.exists(test_split):
+      print("[Evaluation] Evaluating test split benchmark...")
+      subprocess.run(
+          [
+              sys.executable,
+              "scripts/evaluate_model.py",
+              "-m",
+              out_model,
+              "-t",
+              test_split,
+          ],
+          check=True,
+      )
+
+
+def main() -> None:
+  parser = argparse.ArgumentParser(
+      description="Streamlined retraining meta-pipeline for BudouX models."
+  )
+  parser.add_argument(
+      "--lang", type=str, default="ja", help="Language code (default: ja)"
+  )
+  parser.add_argument(
+      "--iter",
+      type=int,
+      default=200000,
+      help="Number of training iterations (default: 200000)",
+  )
+  parser.add_argument(
+      "--split-dir",
+      type=str,
+      default="tmp/splits",
+      help="Directory containing or receiving KNBC splits",
+  )
+  parser.add_argument(
+      "--out-model",
+      type=str,
+      default="",
+      help="Output model JSON path (default: budoux/models/<lang>.json)",
+  )
+  args = parser.parse_args()
+  run_retraining_pipeline(
+      lang=args.lang,
+      iterations=args.iter,
+      split_dir=args.split_dir,
+      out_model=args.out_model,
+  )
+
+
+if __name__ == "__main__":
+  main()

--- a/scripts/synthesize_samples.py
+++ b/scripts/synthesize_samples.py
@@ -278,6 +278,8 @@ def run_agentic_synthesis_pipeline(
     max_keep: int = 15,
     lang: str = "ja",
     outfile: str = "staging_raw.txt",
+    save_dataset: bool = False,
+    append_quality: bool = False,
     client: Optional[genai.Client] = None,
     parser: Optional[budoux.Parser] = None,
 ) -> List[str]:
@@ -332,6 +334,29 @@ def run_agentic_synthesis_pipeline(
       f.write("\n".join(output_lines) + "\n")
     print(f"[Staging] Saved {len(output_lines)} lines directly to {outfile}.")
 
+  if save_dataset and issue_id and output_lines:
+    dataset_dir = os.path.join(
+        os.path.dirname(__file__), "..", "data", "finetuning", lang
+    )
+    os.makedirs(dataset_dir, exist_ok=True)
+    dataset_file = os.path.join(dataset_dir, f"issue_{issue_id}.txt")
+    with open(dataset_file, "w", encoding="utf-8") as f:
+      f.write("\n".join(output_lines) + "\n")
+    print(f"[Dataset] Saved dataset to {dataset_file}.")
+
+  if append_quality and issue_id and output_lines:
+    quality_file = os.path.join(
+        os.path.dirname(__file__), "..", "tests", "quality", f"{lang}.tsv"
+    )
+    if os.path.exists(quality_file):
+      entry = f"gh{issue_id}\t{output_lines[0]}\n"
+      with open(quality_file, "r", encoding="utf-8") as f:
+        existing = f.read()
+      if entry.strip() not in existing:
+        with open(quality_file, "a", encoding="utf-8") as f:
+          f.write(entry)
+        print(f"[Quality Suite] Appended representative test to {quality_file}.")
+
   return output_lines
 
 
@@ -340,28 +365,44 @@ def build_parser() -> argparse.ArgumentParser:
   p = argparse.ArgumentParser(description="Agentic candidate sample synthesis.")
   group = p.add_mutually_exclusive_group(required=True)
   group.add_argument(
-      "--input", "-i", type=str, help="Target string (e.g. 'いよいよ/はじまる')")
+      "--input", "-i", type=str, help="Target string (e.g. 'いよいよ/はじまる')"
+  )
   group.add_argument(
-      "--issue", type=str, help="GitHub bug report number or URL ID")
+      "--issue", type=str, help="GitHub bug report number or URL ID"
+  )
   p.add_argument(
       "--lang",
       type=str,
       default="ja",
-      help="Target model language (default: ja)")
+      help="Target model language (default: ja)",
+  )
   p.add_argument(
       "--num-samples",
       "-n",
       type=int,
       default=30,
-      help="Initial generation count")
+      help="Initial generation count",
+  )
   p.add_argument(
-      "--max-keep", type=int, default=15, help="Pruned final row target")
+      "--max-keep", type=int, default=15, help="Pruned final row target"
+  )
   p.add_argument(
       "--output",
       "-o",
       type=str,
       default="staging_raw.txt",
-      help="Staging destination file")
+      help="Staging destination file",
+  )
+  p.add_argument(
+      "--save-dataset",
+      action="store_true",
+      help="Save output into data/finetuning/<lang>/issue_<issue>.txt",
+  )
+  p.add_argument(
+      "--append-quality",
+      action="store_true",
+      help="Append representative sample into tests/quality/<lang>.tsv",
+  )
   return p
 
 
@@ -374,6 +415,8 @@ def main() -> None:
       max_keep=args.max_keep,
       lang=args.lang,
       outfile=args.output,
+      save_dataset=args.save_dataset,
+      append_quality=args.append_quality,
   )
 
 

--- a/scripts/synthesize_samples.py
+++ b/scripts/synthesize_samples.py
@@ -336,8 +336,7 @@ def run_agentic_synthesis_pipeline(
 
   if save_dataset and issue_id and output_lines:
     dataset_dir = os.path.join(
-        os.path.dirname(__file__), "..", "data", "finetuning", lang
-    )
+        os.path.dirname(__file__), "..", "data", "finetuning", lang)
     os.makedirs(dataset_dir, exist_ok=True)
     dataset_file = os.path.join(dataset_dir, f"issue_{issue_id}.txt")
     with open(dataset_file, "w", encoding="utf-8") as f:
@@ -346,8 +345,7 @@ def run_agentic_synthesis_pipeline(
 
   if append_quality and issue_id and output_lines:
     quality_file = os.path.join(
-        os.path.dirname(__file__), "..", "tests", "quality", f"{lang}.tsv"
-    )
+        os.path.dirname(__file__), "..", "tests", "quality", f"{lang}.tsv")
     if os.path.exists(quality_file):
       entry = f"gh{issue_id}\t{output_lines[0]}\n"
       with open(quality_file, "r", encoding="utf-8") as f:
@@ -355,7 +353,8 @@ def run_agentic_synthesis_pipeline(
       if entry.strip() not in existing:
         with open(quality_file, "a", encoding="utf-8") as f:
           f.write(entry)
-        print(f"[Quality Suite] Appended representative test to {quality_file}.")
+        print(
+            f"[Quality Suite] Appended representative test to {quality_file}.")
 
   return output_lines
 
@@ -365,11 +364,9 @@ def build_parser() -> argparse.ArgumentParser:
   p = argparse.ArgumentParser(description="Agentic candidate sample synthesis.")
   group = p.add_mutually_exclusive_group(required=True)
   group.add_argument(
-      "--input", "-i", type=str, help="Target string (e.g. 'いよいよ/はじまる')"
-  )
+      "--input", "-i", type=str, help="Target string (e.g. 'いよいよ/はじまる')")
   group.add_argument(
-      "--issue", type=str, help="GitHub bug report number or URL ID"
-  )
+      "--issue", type=str, help="GitHub bug report number or URL ID")
   p.add_argument(
       "--lang",
       type=str,
@@ -384,8 +381,7 @@ def build_parser() -> argparse.ArgumentParser:
       help="Initial generation count",
   )
   p.add_argument(
-      "--max-keep", type=int, default=15, help="Pruned final row target"
-  )
+      "--max-keep", type=int, default=15, help="Pruned final row target")
   p.add_argument(
       "--output",
       "-o",

--- a/scripts/tests/test_run_training_pipeline.py
+++ b/scripts/tests/test_run_training_pipeline.py
@@ -16,21 +16,24 @@
 import json
 import os
 import sys
-import unittest
 import tempfile
+import typing
+import unittest
+from unittest.mock import patch
 
 import pytest
 
 LIB_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
 sys.path.insert(0, LIB_PATH)
 
-from scripts import run_training_pipeline
+from scripts import run_training_pipeline  # noqa: E402
 
 
 class TestRunTrainingPipeline(unittest.TestCase):
 
-  @unittest.mock.patch("subprocess.run")
-  def test_run_retraining_pipeline_subprocess(self, mock_run) -> None:
+  @patch("subprocess.run")
+  def test_run_retraining_pipeline_subprocess(self,
+                                              mock_run: typing.Any) -> None:
     with tempfile.TemporaryDirectory() as tmp_dir:
       split_dir = os.path.join(tmp_dir, "splits")
       os.makedirs(split_dir, exist_ok=True)
@@ -39,8 +42,7 @@ class TestRunTrainingPipeline(unittest.TestCase):
 
       out_model = os.path.join(tmp_dir, "model.json")
       run_training_pipeline.run_retraining_pipeline(
-          lang="ja", iterations=10, split_dir=split_dir, out_model=out_model
-      )
+          lang="ja", iterations=10, split_dir=split_dir, out_model=out_model)
 
       self.assertGreaterEqual(mock_run.call_count, 4)
 
@@ -49,15 +51,21 @@ class TestRunTrainingPipeline(unittest.TestCase):
     with tempfile.TemporaryDirectory() as tmp_dir:
       split_dir = os.path.join(tmp_dir, "splits")
       os.makedirs(split_dir, exist_ok=True)
-      with open(os.path.join(split_dir, "knbc_train.txt"), "w", encoding="utf-8") as f:
+      with open(
+          os.path.join(split_dir, "knbc_train.txt"), "w",
+          encoding="utf-8") as f:
         f.write("今日▁は▁良い▁天気▁です。\n")
-      with open(os.path.join(split_dir, "knbc_val.txt"), "w", encoding="utf-8") as f:
+      with open(
+          os.path.join(split_dir, "knbc_val.txt"), "w", encoding="utf-8") as f:
         f.write("明日▁も▁晴れ▁です。\n")
 
       out_model = os.path.join(tmp_dir, "model.json")
       run_training_pipeline.run_retraining_pipeline(
-          lang="ja", iterations=5, split_dir=split_dir, out_model=out_model, weight_factor=1
-      )
+          lang="ja",
+          iterations=5,
+          split_dir=split_dir,
+          out_model=out_model,
+          weight_factor=1)
 
       self.assertTrue(os.path.exists(out_model))
       with open(out_model, "r", encoding="utf-8") as f:

--- a/scripts/tests/test_run_training_pipeline.py
+++ b/scripts/tests/test_run_training_pipeline.py
@@ -1,0 +1,69 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for the training pipeline runner script."""
+
+import json
+import os
+import sys
+import unittest
+import tempfile
+
+import pytest
+
+LIB_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+sys.path.insert(0, LIB_PATH)
+
+from scripts import run_training_pipeline
+
+
+class TestRunTrainingPipeline(unittest.TestCase):
+
+  @unittest.mock.patch("subprocess.run")
+  def test_run_retraining_pipeline_subprocess(self, mock_run) -> None:
+    with tempfile.TemporaryDirectory() as tmp_dir:
+      split_dir = os.path.join(tmp_dir, "splits")
+      os.makedirs(split_dir, exist_ok=True)
+      with open(os.path.join(split_dir, "knbc_train.txt"), "w") as f:
+        f.write("test sentence\n")
+
+      out_model = os.path.join(tmp_dir, "model.json")
+      run_training_pipeline.run_retraining_pipeline(
+          lang="ja", iterations=10, split_dir=split_dir, out_model=out_model
+      )
+
+      self.assertGreaterEqual(mock_run.call_count, 4)
+
+  def test_run_retraining_pipeline_generates_valid_json(self) -> None:
+    pytest.importorskip("jax")
+    with tempfile.TemporaryDirectory() as tmp_dir:
+      split_dir = os.path.join(tmp_dir, "splits")
+      os.makedirs(split_dir, exist_ok=True)
+      with open(os.path.join(split_dir, "knbc_train.txt"), "w", encoding="utf-8") as f:
+        f.write("今日▁は▁良い▁天気▁です。\n")
+      with open(os.path.join(split_dir, "knbc_val.txt"), "w", encoding="utf-8") as f:
+        f.write("明日▁も▁晴れ▁です。\n")
+
+      out_model = os.path.join(tmp_dir, "model.json")
+      run_training_pipeline.run_retraining_pipeline(
+          lang="ja", iterations=5, split_dir=split_dir, out_model=out_model, weight_factor=1
+      )
+
+      self.assertTrue(os.path.exists(out_model))
+      with open(out_model, "r", encoding="utf-8") as f:
+        model_data = json.load(f)
+      self.assertIsInstance(model_data, dict)
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
- Add dataset 3-way split options (--split-dir, --val-ratio, --test-ratio) to scripts/prepare_knbc.py.
- Add --save-dataset and --append-quality output persistence flags to scripts/synthesize_samples.py.
- Add scripts/run_training_pipeline.py to orchestrate dataset preparation, JAX fitting, and evaluation benchmarks.
- Add comprehensive 5-phase Mermaid workflow diagram to scripts/README.md.
- Add unit tests for scripts/run_training_pipeline.py.

TAG=agy