### PR TITLE
Colab CLI support

### DIFF
--- a/scripts/colab_runner.py
+++ b/scripts/colab_runner.py
@@ -1,0 +1,167 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Colab CLI runner module for remote accelerator training.
+
+Implements binary resolution (env var -> PATH), remote session provisioning,
+file transfer, script execution, and auto-cleanup via Python context managers.
+"""
+
+
+import os
+import shutil
+import subprocess
+from typing import Any, List, Optional
+
+
+def get_colab_binary() -> str:
+  """Resolves colab CLI binary path.
+
+  1. Environment variable `COLAB_CLI_PATH`
+  2. System PATH lookup (`shutil.which('colab')` via PyPI `google-colab-cli`)
+
+  Returns:
+    Path to the resolved colab binary.
+
+  Raises:
+    FileNotFoundError: If no valid colab binary is found.
+  """
+  env_path = os.environ.get("COLAB_CLI_PATH")
+  if env_path and os.path.exists(env_path):
+    return env_path
+
+  which_path = shutil.which("colab")
+  if which_path:
+    return which_path
+
+  raise FileNotFoundError(
+      "Colab CLI binary not found. Please install the PyPI package "
+      "'google-colab-cli' (providing the 'colab' CLI executable for managing "
+      "remote Colab runtimes) via: pip install google-colab-cli "
+      "or set the COLAB_CLI_PATH environment variable."
+  )
+
+
+class ColabRunner:
+  """Manages remote Google Colab VM execution lifecycle."""
+
+  def __init__(
+      self,
+      session_name: str = "budoux-train",
+      accelerator: str = "T4",
+      binary_path: Optional[str] = None,
+  ) -> None:
+    """Initializes ColabRunner.
+
+    Args:
+      session_name: Remote session identifier.
+      accelerator: Accelerator type (e.g., 'T4', 'A100', 'L4', 'v6e1', 'v5e1').
+      binary_path: Optional explicit path to colab CLI binary.
+    """
+    self.session_name = session_name
+    self.accelerator = accelerator
+    self.binary_path = binary_path or get_colab_binary()
+    self._is_active = False
+
+  def _run_cmd(
+      self, args: List[str], check: bool = True
+  ) -> subprocess.CompletedProcess[str]:
+    """Executes a colab CLI command subprocess.
+
+    Args:
+      args: Command argument list.
+      check: Whether to raise CalledProcessError on non-zero exit code.
+
+    Returns:
+      CompletedProcess instance.
+    """
+    cmd = [self.binary_path] + args
+    print(f"[Colab CLI] Executing: {' '.join(cmd)}", flush=True)
+    return subprocess.run(cmd, check=check, text=True, capture_output=False)
+
+  def provision_session(self) -> None:
+    """Provisions a new remote Colab session with specified accelerator."""
+    cmd = ["new", "-s", self.session_name]
+    # TPU variants start with a small 'v' (e.g. v6e1, v5e1), GPUs use --gpu flag
+    if self.accelerator.startswith("v"):
+      cmd.extend(["--tpu", self.accelerator])
+    else:
+      cmd.extend(["--gpu", self.accelerator])
+
+
+    print(
+        f"[Colab CLI] Provisioning remote session '{self.session_name}' "
+        f"with accelerator '{self.accelerator}'...",
+        flush=True,
+    )
+    self._run_cmd(cmd)
+    self._is_active = True
+
+  def upload_file(
+      self, local_path: str, remote_path: Optional[str] = None
+  ) -> None:
+    """Uploads a local file to the remote VM."""
+    cmd = ["upload", "-s", self.session_name, local_path]
+    if remote_path:
+      cmd.append(remote_path)
+    print(f"[Colab CLI] Uploading {local_path} -> remote VM...", flush=True)
+    self._run_cmd(cmd)
+
+  def download_file(self, remote_path: str, local_path: str) -> None:
+    """Downloads a file from the remote VM to local workstation."""
+    cmd = ["download", "-s", self.session_name, remote_path, local_path]
+    print(
+        f"[Colab CLI] Downloading remote {remote_path} -> {local_path}...",
+        flush=True,
+    )
+    self._run_cmd(cmd)
+
+  def exec_script(
+      self, script_path: str, output_image: Optional[str] = None
+  ) -> None:
+    """Executes a local Python script remotely on the Colab VM.
+
+    Args:
+      script_path: Path to the local Python script.
+      output_image: Optional local path for intercepted Matplotlib plots.
+    """
+    cmd = ["exec", "-s", self.session_name, "-f", script_path]
+    if output_image:
+      cmd.extend(["--output-image", output_image])
+    print(
+        f"[Colab CLI] Running remote script execution ({script_path})...",
+        flush=True,
+    )
+    self._run_cmd(cmd)
+
+  def stop_session(self) -> None:
+    """Terminates and cleans up the remote Colab session."""
+    if self._is_active:
+      print(
+          f"[Colab CLI] Terminating remote session '{self.session_name}'...",
+          flush=True,
+      )
+      self._run_cmd(["stop", "-s", self.session_name], check=False)
+      self._is_active = False
+
+  def __enter__(self) -> "ColabRunner":
+    self.provision_session()
+    return self
+
+  def __exit__(
+      self,
+      exc_type: Optional[type],
+      exc_val: Optional[BaseException],
+      exc_tb: Optional[Any],
+  ) -> None:
+    self.stop_session()

--- a/scripts/colab_runner.py
+++ b/scripts/colab_runner.py
@@ -125,14 +125,24 @@ class ColabRunner:
 
   def exec_script(self,
                   script_path: str,
-                  output_image: Optional[str] = None) -> None:
+                  output_image: Optional[str] = None,
+                  timeout: float = 43200.0) -> None:
     """Executes a local Python script remotely on the Colab VM.
 
     Args:
       script_path: Path to the local Python script.
       output_image: Optional local path for intercepted Matplotlib plots.
+      timeout: Execution timeout in seconds (default: 43200.0).
     """
-    cmd = ["exec", "-s", self.session_name, "-f", script_path]
+    cmd = [
+        "exec",
+        "-s",
+        self.session_name,
+        "-f",
+        script_path,
+        "--timeout",
+        str(timeout),
+    ]
     if output_image:
       cmd.extend(["--output-image", output_image])
     print(
@@ -140,6 +150,7 @@ class ColabRunner:
         flush=True,
     )
     self._run_cmd(cmd)
+
 
   def stop_session(self) -> None:
     """Terminates and cleans up the remote Colab session."""

--- a/scripts/colab_runner.py
+++ b/scripts/colab_runner.py
@@ -17,7 +17,6 @@ Implements binary resolution (env var -> PATH), remote session provisioning,
 file transfer, script execution, and auto-cleanup via Python context managers.
 """
 
-
 import os
 import shutil
 import subprocess
@@ -48,8 +47,7 @@ def get_colab_binary() -> str:
       "Colab CLI binary not found. Please install the PyPI package "
       "'google-colab-cli' (providing the 'colab' CLI executable for managing "
       "remote Colab runtimes) via: pip install google-colab-cli "
-      "or set the COLAB_CLI_PATH environment variable."
-  )
+      "or set the COLAB_CLI_PATH environment variable.")
 
 
 class ColabRunner:
@@ -73,9 +71,9 @@ class ColabRunner:
     self.binary_path = binary_path or get_colab_binary()
     self._is_active = False
 
-  def _run_cmd(
-      self, args: List[str], check: bool = True
-  ) -> subprocess.CompletedProcess[str]:
+  def _run_cmd(self,
+               args: List[str],
+               check: bool = True) -> subprocess.CompletedProcess[str]:
     """Executes a colab CLI command subprocess.
 
     Args:
@@ -98,7 +96,6 @@ class ColabRunner:
     else:
       cmd.extend(["--gpu", self.accelerator])
 
-
     print(
         f"[Colab CLI] Provisioning remote session '{self.session_name}' "
         f"with accelerator '{self.accelerator}'...",
@@ -107,9 +104,9 @@ class ColabRunner:
     self._run_cmd(cmd)
     self._is_active = True
 
-  def upload_file(
-      self, local_path: str, remote_path: Optional[str] = None
-  ) -> None:
+  def upload_file(self,
+                  local_path: str,
+                  remote_path: Optional[str] = None) -> None:
     """Uploads a local file to the remote VM."""
     cmd = ["upload", "-s", self.session_name, local_path]
     if remote_path:
@@ -126,9 +123,9 @@ class ColabRunner:
     )
     self._run_cmd(cmd)
 
-  def exec_script(
-      self, script_path: str, output_image: Optional[str] = None
-  ) -> None:
+  def exec_script(self,
+                  script_path: str,
+                  output_image: Optional[str] = None) -> None:
     """Executes a local Python script remotely on the Colab VM.
 
     Args:

--- a/scripts/colab_runner.py
+++ b/scripts/colab_runner.py
@@ -151,7 +151,6 @@ class ColabRunner:
     )
     self._run_cmd(cmd)
 
-
   def stop_session(self) -> None:
     """Terminates and cleans up the remote Colab session."""
     if self._is_active:

--- a/scripts/run_training_pipeline.py
+++ b/scripts/run_training_pipeline.py
@@ -15,7 +15,6 @@
 
 import argparse
 import glob
-import json
 import os
 import shutil
 import subprocess
@@ -134,12 +133,10 @@ def run_retraining_pipeline(
     if colab:
       sess = session_name or f"budoux-train-{accelerator}"
       with colab_runner.ColabRunner(
-          session_name=sess, accelerator=accelerator
-      ) as runner:
+          session_name=sess, accelerator=accelerator) as runner:
         runner.upload_file(cleaned_train, "/content/cleaned.txt")
         runner.upload_file(
-            os.path.join(LIB_PATH, "scripts", "train.py"), "/content/train.py"
-        )
+            os.path.join(LIB_PATH, "scripts", "train.py"), "/content/train.py")
         if os.path.exists(val_encoded):
           runner.upload_file(val_encoded, "/content/val_encoded.txt")
 
@@ -163,7 +160,6 @@ def run_retraining_pipeline(
         if os.path.exists(val_encoded):
           remote_args.extend(["--val-data", "/content/val_encoded.txt"])
 
-
         with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False) as f:
           f.write("import subprocess\n")
           f.write(f"subprocess.run({remote_args!r}, check=True)\n")
@@ -175,7 +171,6 @@ def run_retraining_pipeline(
         finally:
           if os.path.exists(launcher_path):
             os.remove(launcher_path)
-
 
     else:
       train_cmd = [
@@ -291,7 +286,6 @@ def main() -> None:
       accelerator=args.accelerator,
       session_name=args.session_name,
   )
-
 
 
 if __name__ == "__main__":

--- a/scripts/run_training_pipeline.py
+++ b/scripts/run_training_pipeline.py
@@ -140,10 +140,11 @@ def run_retraining_pipeline(
         if os.path.exists(val_encoded):
           runner.upload_file(val_encoded, "/content/val_encoded.txt")
 
-        # Outputs training metrics and weights at 10 evenly-spaced checkpoints across total iterations.
-        out_span = max(1, iterations // 10)
+        # Outputs training metrics and weights regularly across total iterations.
+        out_span = min(5000, max(1, iterations // 10))
         remote_args = [
             "python3",
+            "-u",
             "/content/train.py",
             "/content/cleaned.txt",
             "-o",
@@ -157,6 +158,7 @@ def run_retraining_pipeline(
             "--out-span",
             str(out_span),
         ]
+
         if os.path.exists(val_encoded):
           remote_args.extend(["--val-data", "/content/val_encoded.txt"])
 

--- a/scripts/run_training_pipeline.py
+++ b/scripts/run_training_pipeline.py
@@ -15,16 +15,20 @@
 
 import argparse
 import glob
+import json
 import os
 import shutil
 import subprocess
 import sys
 import tarfile
 import tempfile
+import typing
 import urllib.request
 
 LIB_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 sys.path.insert(0, LIB_PATH)
+
+from scripts import colab_runner  # noqa: E402
 
 KNBC_URL = "https://nlp.ist.i.kyoto-u.ac.jp/kuntt/KNBC_v1.0_090925_utf8.tar.bz2"
 
@@ -32,11 +36,16 @@ KNBC_URL = "https://nlp.ist.i.kyoto-u.ac.jp/kuntt/KNBC_v1.0_090925_utf8.tar.bz2"
 def run_retraining_pipeline(
     lang: str = "ja",
     iterations: int = 200000,
+    feature_thres: int = 2,
     split_dir: str = "tmp/splits",
     out_model: str = "",
     weight_factor: int = 100,
+    colab: bool = False,
+    accelerator: str = "T4",
+    session_name: typing.Optional[str] = None,
 ) -> None:
   """Executes end-to-end dataset preparation, JAX fitting, and validation."""
+
   if not out_model:
     out_model = os.path.join("budoux", "models", f"{lang}.json")
 
@@ -122,20 +131,67 @@ def run_retraining_pipeline(
       )
 
     print(f"[Train] Fitting JAX model ({iterations} iterations)...")
-    train_cmd = [
-        sys.executable,
-        "scripts/train.py",
-        cleaned_train,
-        "-o",
-        weights_path,
-        "--iter",
-        str(iterations),
-        "--feature-thres",
-        "2",
-    ]
-    if os.path.exists(val_encoded):
-      train_cmd.extend(["--val-data", val_encoded])
-    subprocess.run(train_cmd, check=True)
+    if colab:
+      sess = session_name or f"budoux-train-{accelerator}"
+      with colab_runner.ColabRunner(
+          session_name=sess, accelerator=accelerator
+      ) as runner:
+        runner.upload_file(cleaned_train, "/content/cleaned.txt")
+        runner.upload_file(
+            os.path.join(LIB_PATH, "scripts", "train.py"), "/content/train.py"
+        )
+        if os.path.exists(val_encoded):
+          runner.upload_file(val_encoded, "/content/val_encoded.txt")
+
+        # Outputs training metrics and weights at 10 evenly-spaced checkpoints across total iterations.
+        out_span = max(1, iterations // 10)
+        remote_args = [
+            "python3",
+            "/content/train.py",
+            "/content/cleaned.txt",
+            "-o",
+            "/content/weights.txt",
+            "--log",
+            "/content/train.log",
+            "--iter",
+            str(iterations),
+            "--feature-thres",
+            str(feature_thres),
+            "--out-span",
+            str(out_span),
+        ]
+        if os.path.exists(val_encoded):
+          remote_args.extend(["--val-data", "/content/val_encoded.txt"])
+
+
+        with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False) as f:
+          f.write("import subprocess\n")
+          f.write(f"subprocess.run({remote_args!r}, check=True)\n")
+          launcher_path = f.name
+
+        try:
+          runner.exec_script(launcher_path)
+          runner.download_file("/content/weights.txt", weights_path)
+        finally:
+          if os.path.exists(launcher_path):
+            os.remove(launcher_path)
+
+
+    else:
+      train_cmd = [
+          sys.executable,
+          "scripts/train.py",
+          cleaned_train,
+          "-o",
+          weights_path,
+          "--iter",
+          str(iterations),
+          "--feature-thres",
+          str(feature_thres),
+      ]
+      if os.path.exists(val_encoded):
+        train_cmd.extend(["--val-data", val_encoded])
+      subprocess.run(train_cmd, check=True)
 
     print(f"[Export] Exporting compact JSON model to {out_model}...")
     subprocess.run(
@@ -189,6 +245,12 @@ def main() -> None:
       help="Number of training iterations (default: 200000)",
   )
   parser.add_argument(
+      "--feature-thres",
+      type=int,
+      default=2,
+      help="Threshold value of minimum feature frequency (default: 2)",
+  )
+  parser.add_argument(
       "--split-dir",
       type=str,
       default="tmp/splits",
@@ -200,13 +262,36 @@ def main() -> None:
       default="",
       help="Output model JSON path (default: budoux/models/<lang>.json)",
   )
+  parser.add_argument(
+      "--colab",
+      action="store_true",
+      help="Offload JAX AdaBoost training step to remote Colab VM.",
+  )
+  parser.add_argument(
+      "--accelerator",
+      type=str,
+      default="T4",
+      help="Accelerator type for Colab VM (default: T4)",
+  )
+
+  parser.add_argument(
+      "--session-name",
+      type=str,
+      default=None,
+      help="Remote Colab session identifier",
+  )
   args = parser.parse_args()
   run_retraining_pipeline(
       lang=args.lang,
       iterations=args.iter,
+      feature_thres=args.feature_thres,
       split_dir=args.split_dir,
       out_model=args.out_model,
+      colab=args.colab,
+      accelerator=args.accelerator,
+      session_name=args.session_name,
   )
+
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_colab_runner.py
+++ b/scripts/tests/test_colab_runner.py
@@ -1,0 +1,117 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for colab_runner.py."""
+
+import os
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+# Module hack
+LIB_PATH = os.path.join(os.path.dirname(__file__), "..", "..")
+sys.path.insert(0, os.path.abspath(LIB_PATH))
+
+from scripts import colab_runner  # noqa: E402
+
+
+class TestGetColabBinary(unittest.TestCase):
+
+  @patch.dict(os.environ, {"COLAB_CLI_PATH": "/custom/colab"})
+  @patch("os.path.exists", return_value=True)
+  def test_env_var_override(self, mock_exists: MagicMock) -> None:
+    binary = colab_runner.get_colab_binary()
+    self.assertEqual(binary, "/custom/colab")
+
+  @patch.dict(os.environ, {}, clear=True)
+  @patch("shutil.which", return_value="/usr/local/bin/colab")
+  def test_path_lookup(self, mock_which: MagicMock) -> None:
+    binary = colab_runner.get_colab_binary()
+    self.assertEqual(binary, "/usr/local/bin/colab")
+
+
+  @patch.dict(os.environ, {}, clear=True)
+  @patch("shutil.which", return_value=None)
+  @patch("os.path.exists", return_value=False)
+  def test_not_found_raises(
+      self, mock_which: MagicMock, mock_exists: MagicMock
+  ) -> None:
+    with self.assertRaises(FileNotFoundError):
+      colab_runner.get_colab_binary()
+
+
+class TestColabRunner(unittest.TestCase):
+
+  @patch("subprocess.run")
+  def test_provision_and_stop(self, mock_run: MagicMock) -> None:
+    runner = colab_runner.ColabRunner(
+        session_name="test-session",
+        accelerator="v6e1",
+        binary_path="/usr/bin/colab",
+    )
+    runner.provision_session()
+    mock_run.assert_called_with(
+        ["/usr/bin/colab", "new", "-s", "test-session", "--tpu", "v6e1"],
+        check=True,
+        text=True,
+        capture_output=False,
+    )
+
+    runner.stop_session()
+    mock_run.assert_called_with(
+        ["/usr/bin/colab", "stop", "-s", "test-session"],
+        check=False,
+        text=True,
+        capture_output=False,
+    )
+
+  @patch("subprocess.run")
+  def test_gpu_provisioning(self, mock_run: MagicMock) -> None:
+    runner = colab_runner.ColabRunner(
+        session_name="gpu-session",
+        accelerator="A100",
+        binary_path="/usr/bin/colab",
+    )
+    runner.provision_session()
+    mock_run.assert_called_with(
+        ["/usr/bin/colab", "new", "-s", "gpu-session", "--gpu", "A100"],
+        check=True,
+        text=True,
+        capture_output=False,
+    )
+
+  @patch("subprocess.run")
+  def test_context_manager(self, mock_run: MagicMock) -> None:
+    with colab_runner.ColabRunner(
+        session_name="ctx-session",
+        accelerator="v6e1",
+        binary_path="/usr/bin/colab",
+    ) as runner:
+      self.assertTrue(runner._is_active)
+      runner.upload_file("local.txt")
+      runner.exec_script("train.py")
+      runner.download_file("remote.txt", "local_out.txt")
+
+    self.assertFalse(runner._is_active)
+    # Total of 5 subprocess calls executed in sequence:
+    # 1. new (provision session)
+    # 2. upload_file
+    # 3. exec_script
+    # 4. download_file
+    # 5. stop (cleanup session on context exit)
+    self.assertEqual(mock_run.call_count, 5)
+
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/scripts/tests/test_colab_runner.py
+++ b/scripts/tests/test_colab_runner.py
@@ -39,13 +39,11 @@ class TestGetColabBinary(unittest.TestCase):
     binary = colab_runner.get_colab_binary()
     self.assertEqual(binary, "/usr/local/bin/colab")
 
-
   @patch.dict(os.environ, {}, clear=True)
   @patch("shutil.which", return_value=None)
   @patch("os.path.exists", return_value=False)
-  def test_not_found_raises(
-      self, mock_which: MagicMock, mock_exists: MagicMock
-  ) -> None:
+  def test_not_found_raises(self, mock_which: MagicMock,
+                            mock_exists: MagicMock) -> None:
     with self.assertRaises(FileNotFoundError):
       colab_runner.get_colab_binary()
 
@@ -110,7 +108,6 @@ class TestColabRunner(unittest.TestCase):
     # 4. download_file
     # 5. stop (cleanup session on context exit)
     self.assertEqual(mock_run.call_count, 5)
-
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_run_training_pipeline.py
+++ b/scripts/tests/test_run_training_pipeline.py
@@ -75,8 +75,7 @@ class TestRunTrainingPipeline(unittest.TestCase):
   @patch("scripts.colab_runner.ColabRunner")
   @patch("subprocess.run")
   def test_run_retraining_pipeline_colab(
-      self, mock_run: MagicMock, mock_colab_runner_cls: MagicMock
-  ) -> None:
+      self, mock_run: MagicMock, mock_colab_runner_cls: MagicMock) -> None:
     mock_runner = MagicMock()
     mock_colab_runner_cls.return_value.__enter__.return_value = mock_runner
 
@@ -105,8 +104,7 @@ class TestRunTrainingPipeline(unittest.TestCase):
       )
 
       mock_colab_runner_cls.assert_called_once_with(
-          session_name="budoux-train-T4", accelerator="T4"
-      )
+          session_name="budoux-train-T4", accelerator="T4")
       self.assertTrue(mock_runner.exec_script.called)
 
       uploaded_remote_paths = [
@@ -115,16 +113,14 @@ class TestRunTrainingPipeline(unittest.TestCase):
       self.assertIn("/content/cleaned.txt", uploaded_remote_paths)
       self.assertIn("/content/train.py", uploaded_remote_paths)
 
-
   @patch("scripts.colab_runner.ColabRunner")
   @patch("subprocess.run")
   def test_colab_download_failure_does_not_mask_error(
-      self, mock_run: MagicMock, mock_colab_runner_cls: MagicMock
-  ) -> None:
+      self, mock_run: MagicMock, mock_colab_runner_cls: MagicMock) -> None:
     mock_runner = MagicMock()
     mock_colab_runner_cls.return_value.__enter__.return_value = mock_runner
-    mock_runner.exec_script.side_effect = RuntimeError("Remote execution failed")
-
+    mock_runner.exec_script.side_effect = RuntimeError(
+        "Remote execution failed")
 
     with tempfile.TemporaryDirectory() as tmp_dir:
       split_dir = os.path.join(tmp_dir, "splits")
@@ -146,4 +142,3 @@ class TestRunTrainingPipeline(unittest.TestCase):
 
 if __name__ == "__main__":
   unittest.main()
-

--- a/scripts/tests/test_run_training_pipeline.py
+++ b/scripts/tests/test_run_training_pipeline.py
@@ -19,7 +19,7 @@ import sys
 import tempfile
 import typing
 import unittest
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -72,6 +72,78 @@ class TestRunTrainingPipeline(unittest.TestCase):
         model_data = json.load(f)
       self.assertIsInstance(model_data, dict)
 
+  @patch("scripts.colab_runner.ColabRunner")
+  @patch("subprocess.run")
+  def test_run_retraining_pipeline_colab(
+      self, mock_run: MagicMock, mock_colab_runner_cls: MagicMock
+  ) -> None:
+    mock_runner = MagicMock()
+    mock_colab_runner_cls.return_value.__enter__.return_value = mock_runner
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+      split_dir = os.path.join(tmp_dir, "splits")
+      os.makedirs(split_dir, exist_ok=True)
+      with open(os.path.join(split_dir, "knbc_train.txt"), "w") as f:
+        f.write("test sentence\n")
+      out_model = os.path.join(tmp_dir, "model.json")
+
+      def fake_download(remote_path: str, local_path: str) -> None:
+
+        if remote_path == "/content/weights.txt":
+          with open(local_path, "w") as f:
+            f.write("foo\t1.0\n")
+
+      mock_runner.download_file.side_effect = fake_download
+
+      run_training_pipeline.run_retraining_pipeline(
+          lang="ja",
+          iterations=10,
+          split_dir=split_dir,
+          out_model=out_model,
+          colab=True,
+          accelerator="T4",
+      )
+
+      mock_colab_runner_cls.assert_called_once_with(
+          session_name="budoux-train-T4", accelerator="T4"
+      )
+      self.assertTrue(mock_runner.exec_script.called)
+
+      uploaded_remote_paths = [
+          call[0][1] for call in mock_runner.upload_file.call_args_list
+      ]
+      self.assertIn("/content/cleaned.txt", uploaded_remote_paths)
+      self.assertIn("/content/train.py", uploaded_remote_paths)
+
+
+  @patch("scripts.colab_runner.ColabRunner")
+  @patch("subprocess.run")
+  def test_colab_download_failure_does_not_mask_error(
+      self, mock_run: MagicMock, mock_colab_runner_cls: MagicMock
+  ) -> None:
+    mock_runner = MagicMock()
+    mock_colab_runner_cls.return_value.__enter__.return_value = mock_runner
+    mock_runner.exec_script.side_effect = RuntimeError("Remote execution failed")
+
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+      split_dir = os.path.join(tmp_dir, "splits")
+      os.makedirs(split_dir, exist_ok=True)
+      with open(os.path.join(split_dir, "knbc_train.txt"), "w") as f:
+        f.write("test sentence\n")
+
+      out_model = os.path.join(tmp_dir, "model.json")
+      with self.assertRaises(RuntimeError) as cm:
+        run_training_pipeline.run_retraining_pipeline(
+            lang="ja",
+            iterations=10,
+            split_dir=split_dir,
+            out_model=out_model,
+            colab=True,
+        )
+      self.assertEqual(str(cm.exception), "Remote execution failed")
+
 
 if __name__ == "__main__":
   unittest.main()
+


### PR DESCRIPTION
## Summary

Adds support for offloading the JAX model fitting step (`train.py`) to a remote Google Colab VM with hardware acceleration (GPU/TPU) via `run_training_pipeline.py --colab`. 

Data preprocessing, encoding, conflict resolution, and quality evaluation remain on the local workstation.

## Changes

- **`scripts/colab_runner.py`**: Added `ColabRunner` context manager to handle remote Colab VM provisioning, file transfers, script execution, and cleanup via `google-colab-cli`.
- **`scripts/run_training_pipeline.py`**: Added `--colab`, `--accelerator` (default `T4`), `--session-name`, and `--feature-thres` CLI flags.
- **`scripts/tests/`**: Added unit tests for `ColabRunner` and pipeline Colab execution.

## Benchmark (10,000 Iterations)

| Metric | Local CPU | Colab T4 GPU | Speedup |
|---|---|---|---|
| **JAX Fitting Time** | ~135.0s | **~35.0s** | **3.85x** ⚡ |
| **Total Pipeline Wall Time** | 148.77s | **68.89s** | **2.16x** |
| **Quality F1 Score** | 92.02% | 92.02% | Identical |
