### PR TITLE
refactor(scripts): unify model evaluation and fix EPS precision bug

### DIFF
--- a/scripts/evaluate_model.py
+++ b/scripts/evaluate_model.py
@@ -26,10 +26,16 @@ sys.path.insert(0, os.path.abspath(LIB_PATH))
 
 import budoux  # noqa: E402
 
-EPS = 1e-9
+
+class EvaluationMetrics(typing.TypedDict):
+  accuracy: float
+  precision: float
+  recall: float
+  fscore: float
+  errors: typing.List[typing.Tuple[str, str]]
 
 
-def evaluate(model_path: str, test_data_path: str) -> typing.Dict[str, float]:
+def evaluate(model_path: str, test_data_path: str) -> EvaluationMetrics:
   """Loads the JSON model and evaluates it against the test dataset.
 
   Args:
@@ -40,8 +46,8 @@ def evaluate(model_path: str, test_data_path: str) -> typing.Dict[str, float]:
       splitting is evaluated.
 
   Returns:
-    Dict[str, float]: A dictionary containing precision, recall, accuracy,
-      and fscore.
+    EvaluationMetrics: A dictionary containing precision, recall, accuracy,
+      fscore, and errors.
   """
   with open(model_path, encoding='utf-8') as f:
     model = json.load(f)
@@ -51,6 +57,7 @@ def evaluate(model_path: str, test_data_path: str) -> typing.Dict[str, float]:
   tn = 0
   fp = 0
   fn = 0
+  errors: typing.List[typing.Tuple[str, str]] = []
 
   is_tsv = test_data_path.endswith('.tsv')
   with open(test_data_path, encoding='utf-8') as f:
@@ -84,6 +91,9 @@ def evaluate(model_path: str, test_data_path: str) -> typing.Dict[str, float]:
 
       raw_sentence = ''.join(raw_chars)
       predicted_chunks = parser.parse(raw_sentence)
+      predicted_sentence = budoux.utils.SEP.join(predicted_chunks)
+      if predicted_sentence != line:
+        errors.append((line, predicted_sentence))
 
       # Build set of chunk start character indices in raw_sentence
       chunk_start_indices = set()
@@ -108,16 +118,19 @@ def evaluate(model_path: str, test_data_path: str) -> typing.Dict[str, float]:
         elif not p and g:
           fn += 1
 
-  accuracy = (tp + tn) / (tp + tn + fp + fn + EPS)
-  precision = tp / (tp + fp + EPS)
-  recall = tp / (tp + fn + EPS)
-  fscore = 2 * precision * recall / (precision + recall + EPS)
+  total = tp + tn + fp + fn
+  accuracy = (tp + tn) / total if total > 0 else 0.0
+  precision = tp / (tp + fp) if (tp + fp) > 0 else 0.0
+  recall = tp / (tp + fn) if (tp + fn) > 0 else 0.0
+  fscore = (2 * precision * recall / (precision + recall) if
+            (precision + recall) > 0 else 0.0)
 
   return {
       'accuracy': accuracy,
       'precision': precision,
       'recall': recall,
       'fscore': fscore,
+      'errors': errors,
   }
 
 
@@ -127,7 +140,8 @@ def main() -> None:
       '-m',
       '--model',
       required=True,
-      help='Path to the compiled model JSON file.')
+      help='Path to the compiled model JSON file.',
+  )
   parser.add_argument(
       '-t',
       '--test-data',

--- a/scripts/tests/test_evaluate_model.py
+++ b/scripts/tests/test_evaluate_model.py
@@ -112,10 +112,11 @@ class TestEvaluateModel(unittest.TestCase):
 
     metrics = evaluate_model.evaluate(self.model_path, self.test_data_path)
 
-    self.assertAlmostEqual(metrics['accuracy'], 1.0)
-    self.assertAlmostEqual(metrics['precision'], 1.0)
-    self.assertAlmostEqual(metrics['recall'], 1.0)
-    self.assertAlmostEqual(metrics['fscore'], 1.0)
+    self.assertEqual(metrics['accuracy'], 1.0)
+    self.assertEqual(metrics['precision'], 1.0)
+    self.assertEqual(metrics['recall'], 1.0)
+    self.assertEqual(metrics['fscore'], 1.0)
+    self.assertEqual(len(metrics['errors']), 0)
 
   def test_evaluate_model_tsv_format(self) -> None:
     tsv_path = os.path.join(self.temp_dir.name, 'test_data.tsv')
@@ -129,9 +130,10 @@ class TestEvaluateModel(unittest.TestCase):
 
     metrics = evaluate_model.evaluate(self.model_path, tsv_path)
     self.assertAlmostEqual(metrics['accuracy'], 2 / 3)
-    self.assertAlmostEqual(metrics['precision'], 1.0)
+    self.assertEqual(metrics['precision'], 1.0)
     self.assertAlmostEqual(metrics['recall'], 2 / 3)
     self.assertAlmostEqual(metrics['fscore'], 0.8)
+    self.assertEqual(len(metrics['errors']), 2)
 
 
 if __name__ == '__main__':

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -21,22 +21,16 @@ import unittest
 LIB_PATH = os.path.join(os.path.dirname(__file__), '..')
 sys.path.insert(0, os.path.abspath(LIB_PATH))
 
-from budoux import load_default_japanese_parser, utils  # noqa (module hack)
+from scripts.evaluate_model import evaluate  # noqa (module hack)
 
 
 class TestQuality(unittest.TestCase):
 
   def test_ja(self) -> None:
-    errors = []
-    parser = load_default_japanese_parser()
-    fp = os.path.join(os.path.dirname(__file__), 'quality', 'ja.tsv')
-    with open(fp, 'r', encoding='utf-8') as f:
-      data = [line.split('\t') for line in f.readlines() if line[0] != '#']
-    expected_sentences = [line[1].strip() for line in data if len(line) > 1]
-    for expected in expected_sentences:
-      result = utils.SEP.join(parser.parse(expected.replace(utils.SEP, '')))
-      if result != expected:
-        errors.append((expected, result))
+    model_path = os.path.join(LIB_PATH, 'budoux', 'models', 'ja.json')
+    quality_path = os.path.join(os.path.dirname(__file__), 'quality', 'ja.tsv')
+    res = evaluate(model_path, quality_path)
+    errors = res['errors']
     self.assertEqual(
         len(errors), 0, 'Failing sentences:\n{}'.format('\n'.join(
             [f'expected:{err[0]}\tactual:{err[1]}' for err in errors])))


### PR DESCRIPTION
- Unify model evaluation logic by sharing evaluate_model.evaluate with tests/test_quality.py.
- Fix EPS precision bug in scripts/evaluate_model.py by replacing unconditional EPS additions with safe zero-guarded division.
- Include sentence mismatches (errors) unconditionally in returned EvaluationMetrics dictionary.
- Update evaluator unit tests for exact 1.0 metric assertions.