### PR TITLE
Apply idiomatic Python simplifications for C4, SIM, FURB, PLR, and PIE rules

### DIFF
--- a/budoux/html_processor.py
+++ b/budoux/html_processor.py
@@ -107,7 +107,7 @@ class HTMLChunkResolver(HTMLParser):
 
   def handle_data(self, data: str) -> None:
     for char in data:
-      if not char == self.chunks_joined[self.scan_index]:
+      if char != self.chunks_joined[self.scan_index]:
         prev_was_whitespace = self.scan_index > 0 and self.chunks_joined[
             self.scan_index - 1].isspace()
         if not self.to_skip and not char.isspace() and not prev_was_whitespace:

--- a/budoux/main.py
+++ b/budoux/main.py
@@ -91,10 +91,8 @@ def parse_args(test: ArgList = None) -> argparse.Namespace:
       prog="budoux",
       formatter_class=(lambda prog: BudouxHelpFormatter(
           prog,
-          **{
-              "width": shutil.get_terminal_size(fallback=(120, 50)).columns,
-              "max_help_position": 30,
-          },
+          width=shutil.get_terminal_size(fallback=(120, 50)).columns,
+          max_help_position=30,
       )),
       description=textwrap.dedent("""\
         BudouX is the successor to Budou,
@@ -145,7 +143,7 @@ def parse_args(test: ArgList = None) -> argparse.Namespace:
       "-V",
       "--version",
       action="version",
-      version="%(prog)s {}".format(budoux.__version__),
+      version=f"%(prog)s {budoux.__version__}",
   )
   if test is not None:
     return parser.parse_args(test)
@@ -184,7 +182,7 @@ def main(test: ArgList = None) -> None:
   try:
     print(_main(test))
   except KeyboardInterrupt:
-    exit(0)
+    sys.exit(0)
 
 
 if __name__ == "__main__":

--- a/budoux/main.py
+++ b/budoux/main.py
@@ -160,10 +160,7 @@ def _main(test: ArgList = None) -> str:
 
   parser = budoux.Parser(model)
   if args.html:
-    if args.text is None:
-      inputs_html = sys.stdin.read()
-    else:
-      inputs_html = args.text
+    inputs_html = sys.stdin.read() if args.text is None else args.text
     res = parser.translate_html_string(inputs_html)
   else:
     if args.text is None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,19 @@ preset = "legacy"
 
 [tool.ruff.lint]
 extend-select = [
+    "C401",
+    "C402",
+    "C408",
+    "C419",
+    "EXE001",
+    "FURB122",
+    "PIE804",
+    "PLR1722",
+    "SIM117",
+    "SIM118",
+    "SIM201",
+    "UP032",
+    "UP034",
     "I",
     "E",
     "W",
@@ -90,22 +103,9 @@ ignore = [
     "RUF012", # Mutable default value for class attribute
     "UP015", # Unnecessary mode argument (e.g. open(..., 'r'))
     "UP031", # Use format specifiers instead of percent format
-    "UP032", # [*] Use f-string instead of `format` call
-    "UP034", # [*] Avoid extraneous parentheses
-    "C401", # Unnecessary generator (rewrite as a set comprehension)
-    "C402", # Unnecessary generator (rewrite as a dict comprehension)
-    "C408", # Unnecessary `dict()` call (rewrite as a literal)
-    "C419", # Unnecessary list comprehension
-    "EXE001", # Shebang is present but file is not executable
-    "FURB122", # [*] Use of `f.write` in a for loop
-    "PIE804", # [*] Unnecessary `dict` kwargs
-    "PLR1722", # Use `sys.exit()` instead of `exit`
     "PYI034", # `__enter__` methods in classes like `ColabRunner` usually return `self` at runtime
     "PYI036", # The argument in `__exit__` should be annotated with `object` or `type[BaseException] | None`
     "SIM115", # Use a context manager for opening files
-    "SIM117", # [*] Use a single `with` statement with multiple contexts instead of nested `with` statements
-    "SIM118", # Use `key in dict` instead of `key in dict.keys()`
-    "SIM201", # Use `...` instead of `...`
     "TRY002", # Create your own exception
     "TRY004", # Prefer `TypeError` exception for invalid type
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,25 +75,18 @@ preset = "legacy"
 
 [tool.ruff.lint]
 extend-select = [
-    "C401",
-    "C402",
-    "C408",
-    "C419",
-    "EXE001",
-    "FURB122",
-    "PIE804",
-    "PLR1722",
-    "SIM117",
-    "SIM118",
-    "SIM201",
-    "UP032",
-    "UP034",
     "I",
     "E",
     "W",
     "F",
     "UP",
     "RUF",
+    "C4",
+    "SIM",
+    "FURB",
+    "PIE",
+    "PLR1722",
+    "EXE",
 ]
 ignore = [
     "E402", # Module level import not at top of file (module hack)

--- a/scripts/build_model.py
+++ b/scripts/build_model.py
@@ -30,7 +30,7 @@ def aggregate_scores(weights: list[str]) -> dict[str, dict[str, float]]:
   Returns:
     model (Dict[string, Dict[string, float]]) The exported model.
   """
-  decision_trees: dict[str, dict[str, float]] = dict()
+  decision_trees: dict[str, dict[str, float]] = {}
   for row in weights:
     row = row.strip()
     if not row:
@@ -55,7 +55,7 @@ def round_model(model: dict[str, dict[str, float]],
   Returns:
     model_rounded (Dict[str, Dict[str, int]]) The rounded model.
   """
-  model_rounded: dict[str, dict[str, int]] = dict()
+  model_rounded: dict[str, dict[str, int]] = {}
   for feature_group, features in model.items():
     for feature_content, score in features.items():
       scaled_score = int(score * scale)

--- a/scripts/encode_data.py
+++ b/scripts/encode_data.py
@@ -158,8 +158,7 @@ def main(test: ArgList = None) -> None:
     lines = p.map(func, range(1, len(sentence) + 1))
 
   with open(entries_filename, 'w', encoding=sys.getdefaultencoding()) as f:
-    for line in lines:
-      f.write(line + '\n')
+    f.writelines(line + '\n' for line in lines)
 
   print('\033[92mEncoded training data is out at: %s\033[0m' % entries_filename)
 

--- a/scripts/find_conflicts.py
+++ b/scripts/find_conflicts.py
@@ -29,7 +29,7 @@ def _reconstruct_text_from_unigram(features: str) -> str:
     if not feat.startswith('UW'):
       continue
     parts = feat.split(':', 1)
-    if not len(parts) == 2:
+    if len(parts) != 2:
       continue
     idx = int(parts[0][2:])
     unigrams[idx] = parts[1]

--- a/scripts/prepare_knbc.py
+++ b/scripts/prepare_knbc.py
@@ -206,8 +206,7 @@ def process_knbc(
     sentences.append(utils.SEP.join(chunks))
 
   with open(outfile, 'w', encoding='utf-8') as f:
-    for s in sentences:
-      f.write(s + '\n')
+    f.writelines(s + '\n' for s in sentences)
   print('\033[92mFull training data is output to: %s\033[0m' % (outfile))
 
   if split_dir:
@@ -240,8 +239,7 @@ def process_knbc(
         (test_path, test_sentences),
     ]:
       with open(path, 'w', encoding='utf-8') as f:
-        for line in split_lines:
-          f.write(line + '\n')
+        f.writelines(line + '\n' for line in split_lines)
 
     print(
         '\033[92m3-Way split dataset written to %s:\n  Train: %s (%d lines)\n  Val:   %s (%d lines)\n  Test:  %s (%d lines)\033[0m'

--- a/scripts/prepare_wisesight.py
+++ b/scripts/prepare_wisesight.py
@@ -48,17 +48,16 @@ def main() -> None:
   source_filepath = args.source_filepath
   target_filepath = args.outfile
 
-  with open(target_filepath, 'w') as outfile:
-    with open(source_filepath) as infile:
-      for line in infile:
-        line = line.strip()
-        line = re.sub(r'https?://[^ ]+', '', line)  # Remove URLs
-        line = re.sub(r'#[^ ]+', '', line)  # Remove hashtags
-        line = regex.compile(r'\p{Emoji_Presentation=Yes}+').sub(
-            '', line)  # Remove emojis
-        line = re.sub(r'\|+', '|', line)  # Remove consecutive separators
-        line = re.sub(r'(\|\s)*\|$', '', line)  # Remove redundant spaces
-        outfile.write(line.replace('|', '▁') + '\n')  # Replace the separators.
+  with open(target_filepath, 'w') as outfile, open(source_filepath) as infile:
+    for line in infile:
+      line = line.strip()
+      line = re.sub(r'https?://[^ ]+', '', line)  # Remove URLs
+      line = re.sub(r'#[^ ]+', '', line)  # Remove hashtags
+      line = regex.compile(r'\p{Emoji_Presentation=Yes}+').sub(
+          '', line)  # Remove emojis
+      line = re.sub(r'\|+', '|', line)  # Remove consecutive separators
+      line = re.sub(r'(\|\s)*\|$', '', line)  # Remove redundant spaces
+      outfile.write(line.replace('|', '▁') + '\n')  # Replace the separators.
   print('\033[92mTraining data is output to: %s\033[0m' % (target_filepath))
 
 

--- a/scripts/run_training_pipeline.py
+++ b/scripts/run_training_pipeline.py
@@ -83,8 +83,7 @@ def run_retraining_pipeline(
       for ft_file in sorted(glob.glob(finetuning_pattern)):
         with open(ft_file, "r", encoding="utf-8") as in_f:
           content = in_f.read()
-        for _ in range(weight_factor):
-          out_f.write(content)
+        out_f.writelines(content for _ in range(weight_factor))
       knbc_train = os.path.join(split_dir, "knbc_train.txt")
       if os.path.exists(knbc_train):
         with open(knbc_train, "r", encoding="utf-8") as in_f:

--- a/scripts/tests/test_encode_data.py
+++ b/scripts/tests/test_encode_data.py
@@ -56,10 +56,7 @@ class TestGetFeature(unittest.TestCase):
   def test_with_invalid(self) -> None:
 
     def find_by_prefix(prefix: str, feature: list[str]) -> bool:
-      for item in feature:
-        if item.startswith(prefix):
-          return True
-      return False
+      return any(item.startswith(prefix) for item in feature)
 
     feature = encode_data.get_feature('a', 'a', encode_data.INVALID, 'a', 'a',
                                       'a')

--- a/scripts/tests/test_synthesize_samples.py
+++ b/scripts/tests/test_synthesize_samples.py
@@ -125,10 +125,11 @@ class TestRunAgenticSynthesisPipeline(unittest.TestCase):
 
   def test_run_pipeline_raises_without_env_or_client(self) -> None:
     mock_parser = MagicMock(spec=budoux.Parser)
-    with patch.dict(os.environ, {"GEMINI_API_KEY": ""}, clear=True):
-      with self.assertRaises(RuntimeError):
-        synthesize_samples.run_agentic_synthesis_pipeline(
-            input_str="いよいよ/はじまる", client=None, parser=mock_parser)
+    with patch.dict(
+        os.environ, {"GEMINI_API_KEY": ""},
+        clear=True), self.assertRaises(RuntimeError):
+      synthesize_samples.run_agentic_synthesis_pipeline(
+          input_str="いよいよ/はじまる", client=None, parser=mock_parser)
 
   @patch("scripts.synthesize_samples.generate_oversample_candidates")
   @patch("scripts.synthesize_samples.prune_linguistic_anomalies")

--- a/scripts/tests/test_train.py
+++ b/scripts/tests/test_train.py
@@ -83,15 +83,15 @@ class TestPreprocess(unittest.TestCase):
     train_data_path = tempfile.NamedTemporaryFile().name
     val_data_path = tempfile.NamedTemporaryFile().name
     with open(train_data_path, 'w') as f:
-      f.write(('1\tfoo\tbar\n'
-               '-1\tfoo\n'
-               '1\tfoo\tbar\tbaz\n'
-               '1\tbar\tfoo\n'
-               '-1\tbaz\tqux\n'))
+      f.write('1\tfoo\tbar\n'
+              '-1\tfoo\n'
+              '1\tfoo\tbar\tbaz\n'
+              '1\tbar\tfoo\n'
+              '-1\tbaz\tqux\n')
     with open(val_data_path, 'w') as f:
-      f.write(('1\tbar\tbaz\n'
-               '-1\txyz\n'
-               '1\tabc\tqux\tfoo\n'))
+      f.write('1\tbar\tbaz\n'
+              '-1\txyz\n'
+              '1\tabc\tqux\tfoo\n')
     train_dataset, features, val_dataset = train.preprocess(
         train_data_path, 1, val_data_path)
 
@@ -123,11 +123,11 @@ class TestPreprocess(unittest.TestCase):
   def test_no_val(self) -> None:
     train_data_path = tempfile.NamedTemporaryFile().name
     with open(train_data_path, 'w') as f:
-      f.write(('1\tfoo\tbar\n'
-               '-1\tfoo\n'
-               '1\tfoo\tbar\tbaz\n'
-               '1\tbar\tfoo\n'
-               '-1\tbaz\tqux\n'))
+      f.write('1\tfoo\tbar\n'
+              '-1\tfoo\n'
+              '1\tfoo\tbar\tbaz\n'
+              '1\tbar\tfoo\n'
+              '-1\tbaz\tqux\n')
     train_dataset, features, val_dataset = train.preprocess(train_data_path, 1)
     self.assertEqual(features, ['foo', 'bar', 'baz'])
     self.assertEqual(train_dataset.Y.tolist(), [1, -1, 1, 1, -1])
@@ -242,7 +242,7 @@ class TestFit(unittest.TestCase):
         msg='The number of lines should equal to the ceil of iteration / out_span plus one for the header'
     )
     self.assertEqual(
-        len(set(len(line) for line in log)),
+        len({len(line) for line in log}),
         1,
         msg='The header and the body should have the same number of columns.')
 
@@ -262,32 +262,32 @@ class TestExtractFeatures(unittest.TestCase):
   def test_with_standard_setup(self) -> None:
     entries_file_path = tempfile.NamedTemporaryFile().name
     with open(entries_file_path, 'w') as f:
-      f.write(('1\tfoo\tbar\n'
-               '-1\tfoo\n'
-               '1\tfoo\tbar\tbaz\n'
-               '1\tbar\tfoo\n'
-               '-1\tbaz\tqux\n'))
+      f.write('1\tfoo\tbar\n'
+              '-1\tfoo\n'
+              '1\tfoo\tbar\tbaz\n'
+              '1\tbar\tfoo\n'
+              '-1\tbaz\tqux\n')
     result = train.extract_features(entries_file_path, 1)
     self.assertEqual(result, ['foo', 'bar', 'baz'])
 
   def test_with_redundant_breaks(self) -> None:
     entries_file_path = tempfile.NamedTemporaryFile().name
     with open(entries_file_path, 'w') as f:
-      f.write(('1\tfoo\tbar\n'
-               '-1\tfoo\n'
-               '1\tfoo\tbar\tbaz\n\n'
-               '1\tbar\tfoo\n'
-               '\n'
-               '-1\tbaz\tqux\n'))
+      f.write('1\tfoo\tbar\n'
+              '-1\tfoo\n'
+              '1\tfoo\tbar\tbaz\n\n'
+              '1\tbar\tfoo\n'
+              '\n'
+              '-1\tbaz\tqux\n')
     result = train.extract_features(entries_file_path, 1)
     self.assertEqual(result, ['foo', 'bar', 'baz'])
 
   def test_with_weighted_entries(self) -> None:
     entries_file_path = tempfile.NamedTemporaryFile().name
     with open(entries_file_path, 'w') as f:
-      f.write(('2\tfoo\n'
-               '-3\tbar\n'
-               '1\tbaz\n'))
+      f.write('2\tfoo\n'
+              '-3\tbar\n'
+              '1\tbaz\n')
     result = train.extract_features(entries_file_path, 1)
     self.assertEqual(result, ['bar', 'foo'])
 
@@ -297,11 +297,11 @@ class TestLoadDataset(unittest.TestCase):
   def test_with_standard_setup(self) -> None:
     entries_file_path = tempfile.NamedTemporaryFile().name
     with open(entries_file_path, 'w') as f:
-      f.write(('1\tfoo\tbar\n'
-               '-1\tfoo\n'
-               '1\tfoo\tbar\tbaz\n'
-               '1\tbar\tfoo\n'
-               '-1\tbaz\tqux\n'))
+      f.write('1\tfoo\tbar\n'
+              '-1\tfoo\n'
+              '1\tfoo\tbar\tbaz\n'
+              '1\tbar\tfoo\n'
+              '-1\tbaz\tqux\n')
     result = train.load_dataset(entries_file_path, {
         'foo': 0,
         'bar': 1,
@@ -314,12 +314,12 @@ class TestLoadDataset(unittest.TestCase):
   def test_with_redundant_breaks(self) -> None:
     entries_file_path = tempfile.NamedTemporaryFile().name
     with open(entries_file_path, 'w') as f:
-      f.write(('1\tfoo\tbar\n'
-               '-1\tfoo\n'
-               '1\tfoo\tbar\tbaz\n\n'
-               '1\tbar\tfoo\n'
-               '\n'
-               '-1\tbaz\tqux\n'))
+      f.write('1\tfoo\tbar\n'
+              '-1\tfoo\n'
+              '1\tfoo\tbar\tbaz\n\n'
+              '1\tbar\tfoo\n'
+              '\n'
+              '-1\tbaz\tqux\n')
     result = train.load_dataset(entries_file_path, {
         'foo': 0,
         'bar': 1,
@@ -332,11 +332,11 @@ class TestLoadDataset(unittest.TestCase):
   def test_with_weighted_samples(self) -> None:
     entries_file_path = tempfile.NamedTemporaryFile().name
     with open(entries_file_path, 'w') as f:
-      f.write(('1\tfoo\tbar\n'
-               '-14\tfoo\n'
-               '10\tfoo\tbar\tbaz\n'
-               '-11\tbar\tfoo\n'
-               '-1\tbaz\tqux\n'))
+      f.write('1\tfoo\tbar\n'
+              '-14\tfoo\n'
+              '10\tfoo\tbar\tbaz\n'
+              '-11\tbar\tfoo\n'
+              '-1\tbaz\tqux\n')
     result = train.load_dataset(entries_file_path, {
         'foo': 0,
         'bar': 1,

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -131,7 +131,7 @@ def preprocess(
         This becomes None if val_data_path is None.
   """
   features = extract_features(train_data_path, feature_thres)
-  feature_index = dict((feature, i) for i, feature in enumerate(features))
+  feature_index = {feature: i for i, feature in enumerate(features)}
   train_dataset = load_dataset(train_data_path, feature_index)
   val_dataset = load_dataset(val_data_path,
                              feature_index) if val_data_path else None

--- a/scripts/translate_model.py
+++ b/scripts/translate_model.py
@@ -46,7 +46,7 @@ def translate_icu(model: dict[str, dict[str, int]]) -> str:
   output = 'jaml {\n'
   for group_name, members in sorted(model.items()):
     output += f'{indent}{group_name}Keys {{\n'
-    for key in members.keys():
+    for key in members:
       output += f'{indent}{indent}"{key}",\n'
     output += f'{indent}}}\n'
     output += f'{indent}{group_name}Values:intvector {{\n'
@@ -65,21 +65,19 @@ def normalize(model: dict[str, typing.Any]) -> dict[str, dict[str, int]]:
   Returns:
     An updated model.
   """
-  is_old_format = all([isinstance(v, int) for v in model.values()])
+  is_old_format = all(isinstance(v, int) for v in model.values())
   if is_old_format:
     output = {}
     sorted_items = sorted(model.items(), key=lambda x: x[0])
     groups = itertools.groupby(sorted_items, key=lambda x: x[0].split(':')[0])
     for group in groups:
-      output[group[0]] = dict(
-          (item[0].split(':')[-1], item[1]) for item in group[1])
+      output[group[0]] = {item[0].split(':')[-1]: item[1] for item in group[1]}
     return output
   try:
-    assert (all([
+    assert (all(
         isinstance(v, int)
         for groups in model.values()
-        for v in groups.values()
-    ])), 'Scores should be integers'
+        for v in groups.values())), 'Scores should be integers'
   except (AssertionError, AttributeError) as e:
     raise Exception('Unsupported model format:', e)
   else:


### PR DESCRIPTION
This change applies idiomatic Python simplifications to resolve 13 Ruff rules across the BudouX project.

Key modifications:
- **Comprehensions & Literals**: Converted `dict()`/`set()` generators to comprehensions or literals (C401, C402, C408) and removed unnecessary dictionary unpacking kwargs (PIE804).
- **Modern Idioms**: Replaced `key in dict.keys()` with `key in dict` (SIM118), updated file loops to use `f.writelines()` (FURB122), simplified nested `with` statements (SIM117), replaced `exit()` with `sys.exit()` (PLR1722), and modernized string formats (UP032).
- **Executable**: Set the executable permission bit on `budoux/main.py` to satisfy `EXE001`.
- **Configuration**: Updated `pyproject.toml` to actively select these rules and prevent future regressions.

---
*PR created automatically by Jules for task [6808140453796042198](https://jules.google.com/task/6808140453796042198) started by @tushuhei*