### PR TITLE
ci: centralize CI commands using Taskfile.yml

### DIFF
--- a/.github/workflows/build-demo.yml
+++ b/.github/workflows/build-demo.yml
@@ -15,15 +15,14 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Setup Task
+        uses: arduino/setup-task@v2
+        with:
+          version: 3.x
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '20'
-      - run: npm install
-        working-directory: ./javascript
-      - run: npm install
-        working-directory: ./demo
-      - run: npm run build
-        working-directory: ./demo
+      - run: task build-demo
       - name: Upload static files as artifact
         id: deployment
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0

--- a/.github/workflows/java-unittest.yml
+++ b/.github/workflows/java-unittest.yml
@@ -3,9 +3,11 @@ on:
   push:
     paths:
       - 'java/**'
+      - 'Taskfile.yml'
   pull_request:
     paths:
       - 'java/**'
+      - 'Taskfile.yml'
 permissions:
   contents: read
 
@@ -23,10 +25,14 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Setup Task
+        uses: arduino/setup-task@v2
+        with:
+          version: 3.x
       - name: Set up JDK 17
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
           java-version: '17'
           distribution: 'temurin'
       - name: Build with Maven
-        run: mvn --batch-mode --update-snapshots -f ./java/pom.xml package
+        run: task test-java

--- a/.github/workflows/javascript-unittest.yml
+++ b/.github/workflows/javascript-unittest.yml
@@ -3,9 +3,11 @@ on:
   push:
     paths:
       - 'javascript/**'
+      - 'Taskfile.yml'
   pull_request:
     paths:
       - 'javascript/**'
+      - 'Taskfile.yml'
 permissions:
   contents: read
 
@@ -25,19 +27,13 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Setup Task
+        uses: arduino/setup-task@v2
+        with:
+          version: 3.x
       - name: Setup Node ${{ matrix.node-version }}
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Install Dependencies
-        run: npm install
-        working-directory: ./javascript
-      - name: Create symlink
-        run: npm link
-        working-directory: ./javascript
-      - name: Build package
-        run: npm run build --if-present
-        working-directory: ./javascript
       - name: Run testcases
-        run: npm test
-        working-directory: ./javascript
+        run: task test-javascript

--- a/.github/workflows/py-unittest.yml
+++ b/.github/workflows/py-unittest.yml
@@ -26,6 +26,10 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Setup Task
+        uses: arduino/setup-task@v2
+        with:
+          version: 3.x
       - name: Setup python ${{ matrix.python-version }}
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
@@ -35,10 +39,10 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install ".[dev]"
       - name: Run unittest
-        run: pytest ./tests
+        run: task test-python
       - name: Install Jax
         if:  ${{ matrix.os != 'windows-latest' && matrix.python-version != '3.10' }}
         run: pip install ".[jaxcpu]"
       - name: Run unittest with Jax
         if:  ${{ matrix.os != 'windows-latest' && matrix.python-version != '3.10' }}
-        run: pytest ./scripts/tests
+        run: task test-python-jax

--- a/.github/workflows/style-check.yml
+++ b/.github/workflows/style-check.yml
@@ -12,6 +12,10 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Setup Task
+        uses: arduino/setup-task@v2
+        with:
+          version: 3.x
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.12'
@@ -20,15 +24,8 @@ jobs:
           pip install --upgrade pip
           pip install ".[dev]"
           pip install ".[jaxcpu]"
-      - name: Run yapf
-        run: |
-          yapf --diff --recursive budoux tests scripts
-      - name: Run pyrefly
-        run: |
-          pyrefly check
-      - name: Run ruff check
-        run: |
-          ruff check
+      - name: Run style checks
+        run: task style-python
   typescript-style-check:
     runs-on: ubuntu-latest
     steps:
@@ -38,13 +35,14 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Setup Task
+        uses: arduino/setup-task@v2
+        with:
+          version: 3.x
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '20'
-      - run: npm install
-        working-directory: ./javascript
-      - run: npm run lint
-        working-directory: ./javascript
+      - run: task style-typescript
   java-style-check:
     runs-on: ubuntu-latest
     steps:
@@ -54,6 +52,10 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Setup Task
+        uses: arduino/setup-task@v2
+        with:
+          version: 3.x
       - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
           java-version: '21'
@@ -74,8 +76,9 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - name: markdownlint
-        uses: nosborn/github-action-markdown-cli@508d6cefd8f0cc99eab5d2d4685b1d5f470042c1
+      - name: Setup Task
+        uses: arduino/setup-task@v2
         with:
-          files: '**/*.md'
-          config_file: .markdownlint.yaml
+          version: 3.x
+      - name: markdownlint
+        run: task style-markdown

--- a/.github/workflows/train_ja_knbc.yml
+++ b/.github/workflows/train_ja_knbc.yml
@@ -11,6 +11,10 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Setup Task
+        uses: arduino/setup-task@v2
+        with:
+          version: 3.x
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
@@ -18,25 +22,8 @@ jobs:
       - name: Install dependencies
         run: |
           pip install ".[jaxcpu]"
-      - name: Prepare KNBC data
-        run: |
-          curl -o knbc.tar.bz2 https://nlp.ist.i.kyoto-u.ac.jp/kuntt/KNBC_v1.0_090925_utf8.tar.bz2
-          tar -xf knbc.tar.bz2
-          python scripts/prepare_knbc.py KNBC_v1.0_090925_utf8 -o source_knbc.txt
-      - name: Encode data
-        run: python scripts/encode_data.py source_knbc.txt -o encoded_knbc.txt
       - name: Train model
-        run: |
-          echo "Starting training..."
-          start_time=$(date +%s)
-          python scripts/train.py encoded_knbc.txt -o weights_knbc.txt --iter 100000
-          end_time=$(date +%s)
-          duration=$((end_time - start_time))
-          echo "Training finished."
-          echo "Duration: $duration seconds"
-          echo "Duration: $(($duration / 60)) minutes and $(($duration % 60)) seconds"
-      - name: Build model
-        run: python scripts/build_model.py weights_knbc.txt -o model.json
+        run: task train-ja-knbc
       - name: Upload artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,0 +1,63 @@
+version: '3'
+
+tasks:
+  build-demo:
+    desc: Build the demo application
+    cmds:
+      - npm install
+      - cd ../demo && npm install
+      - cd ../demo && npm run build
+    dir: javascript
+
+  test-java:
+    desc: Run Java unit tests
+    cmds:
+      - mvn --batch-mode --update-snapshots -f ./java/pom.xml package
+
+  test-javascript:
+    desc: Run JavaScript unit tests
+    dir: javascript
+    cmds:
+      - npm install
+      - npm link
+      - npm run build --if-present
+      - npm test
+
+  test-python:
+    desc: Run Python unit tests
+    cmds:
+      - pytest ./tests
+
+  test-python-jax:
+    desc: Run Python unit tests with Jax
+    cmds:
+      - pytest ./scripts/tests
+
+  style-python:
+    desc: Run Python style checks
+    cmds:
+      - yapf --diff --recursive budoux tests scripts
+      - pyrefly check
+      - ruff check
+
+  style-typescript:
+    desc: Run TypeScript style checks
+    dir: javascript
+    cmds:
+      - npm install
+      - npm run lint
+
+  style-markdown:
+    desc: Run Markdown style check
+    cmds:
+      - npx markdownlint-cli '**/*.md' -c .markdownlint.yaml
+
+  train-ja-knbc:
+    desc: Train Japanese Model (KNBC)
+    cmds:
+      - curl -o knbc.tar.bz2 https://nlp.ist.i.kyoto-u.ac.jp/kuntt/KNBC_v1.0_090925_utf8.tar.bz2
+      - tar -xf knbc.tar.bz2
+      - python scripts/prepare_knbc.py KNBC_v1.0_090925_utf8 -o source_knbc.txt
+      - python scripts/encode_data.py source_knbc.txt -o encoded_knbc.txt
+      - python scripts/train.py encoded_knbc.txt -o weights_knbc.txt --iter 100000
+      - python scripts/build_model.py weights_knbc.txt -o model.json


### PR DESCRIPTION
This patch resolves the issue of duplicated CI commands across multiple GitHub Actions configurations by centralizing them within a new `Taskfile.yml`. The following workflows were updated to utilize the tasks defined in `Taskfile.yml`:
- `build-demo.yml`
- `java-unittest.yml`
- `javascript-unittest.yml`
- `py-unittest.yml`
- `style-check.yml`
- `train_ja_knbc.yml`

This setup makes local development configurations identical to CI runs, simplifying maintenance.

---
*PR created automatically by Jules for task [13464825846147420719](https://jules.google.com/task/13464825846147420719) started by @tushuhei*