### PR TITLE
Refactor code to fix Ruff rules and update pyproject.toml

### DIFF
--- a/budoux/html_processor.py
+++ b/budoux/html_processor.py
@@ -81,7 +81,7 @@ class HTMLChunkResolver(HTMLParser):
       if attr[1] is None:
         attr_pairs.append(' ' + attr[0])
       else:
-        attr_pairs.append(' %s="%s"' % (attr[0], attr[1]))
+        attr_pairs.append(f' {attr[0]}="{attr[1]}"')
     encoded_attrs = ''.join(attr_pairs)
     self.element_stack.put(ElementState(tag, self.to_skip))
     if tag.upper() in SKIP_NODES:
@@ -89,10 +89,10 @@ class HTMLChunkResolver(HTMLParser):
         self.scan_index += 1
         self.output += self.separator
       self.to_skip = True
-    self.output += '<%s%s>' % (tag, encoded_attrs)
+    self.output += f'<{tag}{encoded_attrs}>'
 
   def handle_endtag(self, tag: str) -> None:
-    self.output += '</%s>' % (tag)
+    self.output += f'</{tag}>'
     while not self.element_stack.empty():
       state = self.element_stack.get_nowait()
       if state.tag == tag:
@@ -144,5 +144,5 @@ def resolve(phrases: list[str], html: str, separator: str = '\u200b') -> str:
   """
   resolver = HTMLChunkResolver(phrases, separator)
   resolver.feed(html)
-  result = '<span style="%s">%s</span>' % (PARENT_CSS_STYLE, resolver.output)
+  result = f'<span style="{PARENT_CSS_STYLE}">{resolver.output}</span>'
   return result

--- a/budoux/main.py
+++ b/budoux/main.py
@@ -155,7 +155,7 @@ def _main(test: ArgList = None) -> str:
   args = parse_args(test=test)
   model_path = args.lang or args.model
   # Using open() directly assuming model_path is a path-like object.
-  with open(model_path, 'r', encoding='utf-8') as f:
+  with open(model_path, encoding='utf-8') as f:
     model = json.load(f)
 
   parser = budoux.Parser(model)

--- a/bump_version.py
+++ b/bump_version.py
@@ -35,7 +35,7 @@ def main():
   # This turns "1.2.3-rc4" into "1.2.3rc4"
   python_version = re.sub(r'-(rc|alpha|beta|preview)', r'\1', new_version)
   init_file = 'budoux/__init__.py'
-  with open(init_file, 'r') as f:
+  with open(init_file) as f:
     content = f.read()
   new_content = re.sub(r'(__version__\s+=\s+[\'"])([\.\-\w]+)([\'"])',
                        rf'\g<1>{python_version}\g<3>', content)
@@ -44,7 +44,7 @@ def main():
 
   # Updates JavaScript port version number
   package_json_path = 'javascript/package.json'
-  with open(package_json_path, 'r') as f:
+  with open(package_json_path) as f:
     package_data = json.load(f)
     current_version = package_data.get('version')
 
@@ -55,7 +55,7 @@ def main():
     print(f"JavaScript version is already {new_version}, skipping npm version.")
 
   cli_file = 'javascript/src/cli.ts'
-  with open(cli_file, 'r') as f:
+  with open(cli_file) as f:
     content = f.read()
   new_content = re.sub(r'(const\s+CLI_VERSION\s+=\s+[\'"])([\.\-\w]+)([\'"])',
                        rf'\g<1>{new_version}\g<3>', content)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,18 +87,10 @@ extend-select = [
     "PIE",
     "PLR1722",
     "EXE",
+    "PYI",
+    "TRY",
 ]
 ignore = [
     "E402", # Module level import not at top of file (module hack)
     "E501", # Line too long (handled by yapf)
-    "RUF001", # String contains ambiguous character (e.g. fullwidth punctuation in test data)
-    "RUF005", # Consider iterable unpacking instead of concatenation
-    "RUF012", # Mutable default value for class attribute
-    "UP015", # Unnecessary mode argument (e.g. open(..., 'r'))
-    "UP031", # Use format specifiers instead of percent format
-    "PYI034", # `__enter__` methods in classes like `ColabRunner` usually return `self` at runtime
-    "PYI036", # The argument in `__exit__` should be annotated with `object` or `type[BaseException] | None`
-    "SIM115", # Use a context manager for opening files
-    "TRY002", # Create your own exception
-    "TRY004", # Prefer `TypeError` exception for invalid type
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,9 +88,11 @@ extend-select = [
     "PLR1722",
     "EXE",
     "PYI",
-    "TRY",
+    "TRY002",
+    "TRY004",
 ]
 ignore = [
     "E402", # Module level import not at top of file (module hack)
     "E501", # Line too long (handled by yapf)
+    "RUF001", # String contains ambiguous character (e.g. fullwidth punctuation in test data)
 ]

--- a/scripts/colab_runner.py
+++ b/scripts/colab_runner.py
@@ -20,7 +20,7 @@ file transfer, script execution, and auto-cleanup via Python context managers.
 import os
 import shutil
 import subprocess
-from typing import Any
+import typing
 
 
 def get_colab_binary() -> str:
@@ -161,14 +161,14 @@ class ColabRunner:
       self._run_cmd(["stop", "-s", self.session_name], check=False)
       self._is_active = False
 
-  def __enter__(self) -> "ColabRunner":
+  def __enter__(self) -> typing.Self:
     self.provision_session()
     return self
 
   def __exit__(
       self,
-      exc_type: type | None,
+      exc_type: object,
       exc_val: BaseException | None,
-      exc_tb: Any | None,
+      exc_tb: object,
   ) -> None:
     self.stop_session()

--- a/scripts/colab_runner.py
+++ b/scripts/colab_runner.py
@@ -83,7 +83,7 @@ class ColabRunner:
     Returns:
       CompletedProcess instance.
     """
-    cmd = [self.binary_path] + args
+    cmd = [self.binary_path, *args]
     print(f"[Colab CLI] Executing: {' '.join(cmd)}", flush=True)
     return subprocess.run(cmd, check=check, text=True, capture_output=False)
 

--- a/scripts/encode_data.py
+++ b/scripts/encode_data.py
@@ -122,7 +122,7 @@ def process(i: int, sentence: str, sep_indices: set[int], scale: int) -> str:
                         sentence[i + 1] if i + 1 < len(sentence) else INVALID,
                         sentence[i + 2] if i + 2 < len(sentence) else INVALID)
   positive = i in sep_indices
-  line = '\t'.join([f'{scale}' if positive else f'{-scale}'] + feature)
+  line = '\t'.join([f'{scale}' if positive else f'{-scale}', *feature])
   return line
 
 

--- a/scripts/encode_data.py
+++ b/scripts/encode_data.py
@@ -122,7 +122,7 @@ def process(i: int, sentence: str, sep_indices: set[int], scale: int) -> str:
                         sentence[i + 1] if i + 1 < len(sentence) else INVALID,
                         sentence[i + 2] if i + 2 < len(sentence) else INVALID)
   positive = i in sep_indices
-  line = '\t'.join(['%d' % (scale) if positive else '%d' % (-scale)] + feature)
+  line = '\t'.join([f'{scale}' if positive else f'{-scale}'] + feature)
   return line
 
 
@@ -160,7 +160,7 @@ def main(test: ArgList = None) -> None:
   with open(entries_filename, 'w', encoding=sys.getdefaultencoding()) as f:
     f.writelines(line + '\n' for line in lines)
 
-  print('\033[92mEncoded training data is out at: %s\033[0m' % entries_filename)
+  print(f'\033[92mEncoded training data is out at: {entries_filename}\033[0m')
 
 
 if __name__ == '__main__':

--- a/scripts/find_conflicts.py
+++ b/scripts/find_conflicts.py
@@ -59,7 +59,7 @@ def find_conflicts(data_path: str,
   total_data_points = 0
 
   # First pass: identify conflicts
-  with open(data_path, 'r', encoding='utf-8') as f:
+  with open(data_path, encoding='utf-8') as f:
     for line in f:
       cols = line.strip('\n').split('\t')
       if len(cols) < 2:
@@ -145,7 +145,7 @@ def find_conflicts(data_path: str,
 
   # Second pass: write out resolved file
   with open(
-      data_path, 'r', encoding='utf-8') as fin, open(
+      data_path, encoding='utf-8') as fin, open(
           output_path, 'w', encoding='utf-8') as fout:
     for line in fin:
       cols = line.strip('\n').split('\t')

--- a/scripts/prepare_knbc.py
+++ b/scripts/prepare_knbc.py
@@ -197,7 +197,8 @@ def process_knbc(
     if file[-11:] != '-morph.html':
       continue
     parser = KNBCHTMLParser(granularity)
-    data = open(os.path.join(html_dir, file)).read()
+    with open(os.path.join(html_dir, file)) as f:
+      data = f.read()
     parser.feed(data)
     chunks = parser.chunks
     chunks = postprocess(chunks)
@@ -207,7 +208,7 @@ def process_knbc(
 
   with open(outfile, 'w', encoding='utf-8') as f:
     f.writelines(s + '\n' for s in sentences)
-  print('\033[92mFull training data is output to: %s\033[0m' % (outfile))
+  print(f'\033[92mFull training data is output to: {outfile}\033[0m')
 
   if split_dir:
     valid_ratios = (0.0 <= val_ratio <= 1.0) and (
@@ -242,9 +243,8 @@ def process_knbc(
         f.writelines(line + '\n' for line in split_lines)
 
     print(
-        '\033[92m3-Way split dataset written to %s:\n  Train: %s (%d lines)\n  Val:   %s (%d lines)\n  Test:  %s (%d lines)\033[0m'
-        % (split_dir, train_path, len(train_sentences), val_path,
-           len(val_sentences), test_path, len(test_sentences)))
+        f'\033[92m3-Way split dataset written to {split_dir}:\n  Train: {train_path} ({len(train_sentences)} lines)\n  Val:   {val_path} ({len(val_sentences)} lines)\n  Test:  {test_path} ({len(test_sentences)} lines)\033[0m'
+    )
 
 
 def main() -> None:

--- a/scripts/prepare_wisesight.py
+++ b/scripts/prepare_wisesight.py
@@ -58,7 +58,7 @@ def main() -> None:
       line = re.sub(r'\|+', '|', line)  # Remove consecutive separators
       line = re.sub(r'(\|\s)*\|$', '', line)  # Remove redundant spaces
       outfile.write(line.replace('|', '▁') + '\n')  # Replace the separators.
-  print('\033[92mTraining data is output to: %s\033[0m' % (target_filepath))
+  print(f'\033[92mTraining data is output to: {target_filepath}\033[0m')
 
 
 if __name__ == '__main__':

--- a/scripts/run_training_pipeline.py
+++ b/scripts/run_training_pipeline.py
@@ -81,12 +81,12 @@ def run_retraining_pipeline(
     )
     with open(weighted_train, "w", encoding="utf-8") as out_f:
       for ft_file in sorted(glob.glob(finetuning_pattern)):
-        with open(ft_file, "r", encoding="utf-8") as in_f:
+        with open(ft_file, encoding="utf-8") as in_f:
           content = in_f.read()
         out_f.writelines(content for _ in range(weight_factor))
       knbc_train = os.path.join(split_dir, "knbc_train.txt")
       if os.path.exists(knbc_train):
-        with open(knbc_train, "r", encoding="utf-8") as in_f:
+        with open(knbc_train, encoding="utf-8") as in_f:
           shutil.copyfileobj(in_f, out_f)
 
     encoded_train = os.path.join(tmp, "encoded.txt")

--- a/scripts/synthesize_samples.py
+++ b/scripts/synthesize_samples.py
@@ -287,7 +287,7 @@ def run_agentic_synthesis_pipeline(
   if not parser:
     model_path = os.path.join(
         os.path.dirname(__file__), "..", "budoux", "models", f"{lang}.json")
-    with open(model_path, "r", encoding="utf-8") as f:
+    with open(model_path, encoding="utf-8") as f:
       parser = budoux.Parser(json.load(f))
 
   if not client and (issue_id or num_candidates > 0):
@@ -348,7 +348,7 @@ def run_agentic_synthesis_pipeline(
         os.path.dirname(__file__), "..", "tests", "quality", f"{lang}.tsv")
     if os.path.exists(quality_file):
       entry = f"gh{issue_id}\t{output_lines[0]}\n"
-      with open(quality_file, "r", encoding="utf-8") as f:
+      with open(quality_file, encoding="utf-8") as f:
         existing = f.read()
       if entry.strip() not in existing:
         with open(quality_file, "a", encoding="utf-8") as f:

--- a/scripts/tests/test_encode_data.py
+++ b/scripts/tests/test_encode_data.py
@@ -15,6 +15,7 @@
 
 import os
 import sys
+import typing
 import unittest
 
 # module hack
@@ -123,7 +124,7 @@ class TestArgParse(unittest.TestCase):
 class TestProcess(unittest.TestCase):
 
   sentence = '六本木ヒルズでお昼を食べる。'
-  sep_indices = {7, 10, 13}
+  sep_indices: typing.ClassVar[set[int]] = {7, 10, 13}
 
   def test_on_negative_point_with_scale(self) -> None:
     line = encode_data.process(8, self.sentence, self.sep_indices, 16)

--- a/scripts/tests/test_find_conflicts.py
+++ b/scripts/tests/test_find_conflicts.py
@@ -45,7 +45,7 @@ class TestFindConflicts(unittest.TestCase):
     find_conflicts.find_conflicts(
         self.input_file, self.output_file, threshold=1.0)
 
-    with open(self.output_file, 'r', encoding='utf-8') as f:
+    with open(self.output_file, encoding='utf-8') as f:
       lines = f.readlines()
 
     self.assertEqual(len(lines), 4)
@@ -60,7 +60,7 @@ class TestFindConflicts(unittest.TestCase):
     find_conflicts.find_conflicts(
         self.input_file, self.output_file, threshold=1.0)
 
-    with open(self.output_file, 'r', encoding='utf-8') as f:
+    with open(self.output_file, encoding='utf-8') as f:
       lines = f.readlines()
 
     self.assertEqual(len(lines), 1)
@@ -78,7 +78,7 @@ class TestFindConflicts(unittest.TestCase):
     find_conflicts.find_conflicts(
         self.input_file, self.output_file, threshold=0.8)
 
-    with open(self.output_file, 'r', encoding='utf-8') as f:
+    with open(self.output_file, encoding='utf-8') as f:
       lines = f.readlines()
 
     self.assertEqual(len(lines), 3)
@@ -97,7 +97,7 @@ class TestFindConflicts(unittest.TestCase):
     find_conflicts.find_conflicts(
         self.input_file, self.output_file, threshold=0.8)
 
-    with open(self.output_file, 'r', encoding='utf-8') as f:
+    with open(self.output_file, encoding='utf-8') as f:
       lines = f.readlines()
 
     self.assertEqual(len(lines), 1)
@@ -112,7 +112,7 @@ class TestFindConflicts(unittest.TestCase):
     find_conflicts.find_conflicts(
         self.input_file, self.output_file, threshold=1.0)
 
-    with open(self.output_file, 'r', encoding='utf-8') as f:
+    with open(self.output_file, encoding='utf-8') as f:
       lines = f.readlines()
 
     self.assertEqual(len(lines), 0)

--- a/scripts/tests/test_run_training_pipeline.py
+++ b/scripts/tests/test_run_training_pipeline.py
@@ -68,7 +68,7 @@ class TestRunTrainingPipeline(unittest.TestCase):
           weight_factor=1)
 
       self.assertTrue(os.path.exists(out_model))
-      with open(out_model, "r", encoding="utf-8") as f:
+      with open(out_model, encoding="utf-8") as f:
         model_data = json.load(f)
       self.assertIsInstance(model_data, dict)
 

--- a/scripts/tests/test_train.py
+++ b/scripts/tests/test_train.py
@@ -80,8 +80,12 @@ class TestArgParse(unittest.TestCase):
 class TestPreprocess(unittest.TestCase):
 
   def test_standard_setup(self) -> None:
-    train_data_path = tempfile.NamedTemporaryFile().name
-    val_data_path = tempfile.NamedTemporaryFile().name
+    with tempfile.NamedTemporaryFile(delete=False) as tf:
+      train_data_path = tf.name
+      self.addCleanup(os.remove, tf.name)
+    with tempfile.NamedTemporaryFile(delete=False) as tf:
+      val_data_path = tf.name
+      self.addCleanup(os.remove, tf.name)
     with open(train_data_path, 'w') as f:
       f.write('1\tfoo\tbar\n'
               '-1\tfoo\n'
@@ -118,10 +122,12 @@ class TestPreprocess(unittest.TestCase):
       self.assertEqual(val_dataset.X_rows.tolist(), [0, 0, 2])
       self.assertEqual(val_dataset.X_cols.tolist(), [1, 2, 0])
     else:
-      raise ValueError('val_dataset is not an instance of Dataset.')
+      raise TypeError('val_dataset is not an instance of Dataset.')
 
   def test_no_val(self) -> None:
-    train_data_path = tempfile.NamedTemporaryFile().name
+    with tempfile.NamedTemporaryFile(delete=False) as tf:
+      train_data_path = tf.name
+      self.addCleanup(os.remove, tf.name)
     with open(train_data_path, 'w') as f:
       f.write('1\tfoo\tbar\n'
               '-1\tfoo\n'
@@ -204,8 +210,12 @@ class TestUpdate(unittest.TestCase):
 class TestFit(unittest.TestCase):
 
   def test_fit(self) -> None:
-    weights_file_path = tempfile.NamedTemporaryFile().name
-    log_file_path = tempfile.NamedTemporaryFile().name
+    with tempfile.NamedTemporaryFile(delete=False) as tf:
+      weights_file_path = tf.name
+      self.addCleanup(os.remove, tf.name)
+    with tempfile.NamedTemporaryFile(delete=False) as tf:
+      log_file_path = tf.name
+      self.addCleanup(os.remove, tf.name)
     # Prepare a dataset that the 2nd feature (= the 2nd col in X) perfectly
     # correlates with Y in a negative way.
     X = jnp.array([
@@ -253,14 +263,14 @@ class TestFit(unittest.TestCase):
     self.assertEqual(scores.shape[0], len(features))
     loaded_scores = jnp.array([model.get(feature, 0) for feature in features])
     self.assertTrue(jnp.all(jnp.isclose(scores, loaded_scores)))
-    os.remove(weights_file_path)
-    os.remove(log_file_path)
 
 
 class TestExtractFeatures(unittest.TestCase):
 
   def test_with_standard_setup(self) -> None:
-    entries_file_path = tempfile.NamedTemporaryFile().name
+    with tempfile.NamedTemporaryFile(delete=False) as tf:
+      entries_file_path = tf.name
+      self.addCleanup(os.remove, tf.name)
     with open(entries_file_path, 'w') as f:
       f.write('1\tfoo\tbar\n'
               '-1\tfoo\n'
@@ -271,7 +281,9 @@ class TestExtractFeatures(unittest.TestCase):
     self.assertEqual(result, ['foo', 'bar', 'baz'])
 
   def test_with_redundant_breaks(self) -> None:
-    entries_file_path = tempfile.NamedTemporaryFile().name
+    with tempfile.NamedTemporaryFile(delete=False) as tf:
+      entries_file_path = tf.name
+      self.addCleanup(os.remove, tf.name)
     with open(entries_file_path, 'w') as f:
       f.write('1\tfoo\tbar\n'
               '-1\tfoo\n'
@@ -283,7 +295,9 @@ class TestExtractFeatures(unittest.TestCase):
     self.assertEqual(result, ['foo', 'bar', 'baz'])
 
   def test_with_weighted_entries(self) -> None:
-    entries_file_path = tempfile.NamedTemporaryFile().name
+    with tempfile.NamedTemporaryFile(delete=False) as tf:
+      entries_file_path = tf.name
+      self.addCleanup(os.remove, tf.name)
     with open(entries_file_path, 'w') as f:
       f.write('2\tfoo\n'
               '-3\tbar\n'
@@ -295,7 +309,9 @@ class TestExtractFeatures(unittest.TestCase):
 class TestLoadDataset(unittest.TestCase):
 
   def test_with_standard_setup(self) -> None:
-    entries_file_path = tempfile.NamedTemporaryFile().name
+    with tempfile.NamedTemporaryFile(delete=False) as tf:
+      entries_file_path = tf.name
+      self.addCleanup(os.remove, tf.name)
     with open(entries_file_path, 'w') as f:
       f.write('1\tfoo\tbar\n'
               '-1\tfoo\n'
@@ -312,7 +328,9 @@ class TestLoadDataset(unittest.TestCase):
     self.assertEqual(result.Y.tolist(), [1, -1, 1, 1, -1])
 
   def test_with_redundant_breaks(self) -> None:
-    entries_file_path = tempfile.NamedTemporaryFile().name
+    with tempfile.NamedTemporaryFile(delete=False) as tf:
+      entries_file_path = tf.name
+      self.addCleanup(os.remove, tf.name)
     with open(entries_file_path, 'w') as f:
       f.write('1\tfoo\tbar\n'
               '-1\tfoo\n'
@@ -330,7 +348,9 @@ class TestLoadDataset(unittest.TestCase):
     self.assertEqual(result.Y.tolist(), [1, -1, 1, 1, -1])
 
   def test_with_weighted_samples(self) -> None:
-    entries_file_path = tempfile.NamedTemporaryFile().name
+    with tempfile.NamedTemporaryFile(delete=False) as tf:
+      entries_file_path = tf.name
+      self.addCleanup(os.remove, tf.name)
     with open(entries_file_path, 'w') as f:
       f.write('1\tfoo\tbar\n'
               '-14\tfoo\n'

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -257,7 +257,7 @@ def fit(dataset_train: Dataset, dataset_val: Dataset | None,
     if dataset_val:
       f.write('\ttest_accuracy\ttest_precision\ttest_recall\ttest_fscore')
     f.write('\n')
-  print('Outputting learned weights to %s ...' % (weights_filename))
+  print(f'Outputting learned weights to {weights_filename} ...')
 
   M = len(features)
   scores = jnp.zeros(M)
@@ -270,44 +270,38 @@ def fit(dataset_train: Dataset, dataset_val: Dataset | None,
 
   def output_progress(t: int) -> None:
     with open(weights_filename, 'a') as f:
-      f.write('\n'.join('%s\t%.6f' % p for p in feature_score_buffer) + '\n')
+      f.write('\n'.join(f'{p[0]}\t{p[1]:.6f}' for p in feature_score_buffer) +
+              '\n')
     feature_score_buffer.clear()
 
-    print('=== %s ===' % t)
+    print(f'=== {t} ===')
     print()
 
     with open(log_filename, 'a') as f:
       pred_train = pred(scores, dataset_train.X_rows, dataset_train.X_cols,
                         N_train)
       metrics_train = get_metrics(pred_train, Y_train)
-      print('train accuracy:\t%.5f' % metrics_train.accuracy)
-      print('train prec.:\t%.5f' % metrics_train.precision)
-      print('train recall:\t%.5f' % metrics_train.recall)
-      print('train fscore:\t%.5f' % metrics_train.fscore)
+      print(f'train accuracy:\t{metrics_train.accuracy:.5f}')
+      print(f'train prec.:\t{metrics_train.precision:.5f}')
+      print(f'train recall:\t{metrics_train.recall:.5f}')
+      print(f'train fscore:\t{metrics_train.fscore:.5f}')
       print()
-      f.write('%d\t%.5f\t%.5f\t%.5f\t%.5f' % (
-          t,
-          metrics_train.accuracy,
-          metrics_train.precision,
-          metrics_train.recall,
-          metrics_train.fscore,
-      ))
+      f.write(
+          f'{t}\t{metrics_train.accuracy:.5f}\t{metrics_train.precision:.5f}\t{metrics_train.recall:.5f}\t{metrics_train.fscore:.5f}'
+      )
 
       if dataset_val:
         pred_test = pred(scores, dataset_val.X_rows, dataset_val.X_cols, N_test)
         metrics_test = get_metrics(pred_test, Y_test)
-        print('test accuracy:\t%.5f' % metrics_test.accuracy)
-        print('test prec.:\t%.5f' % metrics_test.precision)
-        print('test recall:\t%.5f' % metrics_test.recall)
-        print('test fscore:\t%.5f' % metrics_test.fscore)
+        print(f'test accuracy:\t{metrics_test.accuracy:.5f}')
+        print(f'test prec.:\t{metrics_test.precision:.5f}')
+        print(f'test recall:\t{metrics_test.recall:.5f}')
+        print(f'test fscore:\t{metrics_test.fscore:.5f}')
         print()
 
-        f.write('\t%.5f\t%.5f\t%.5f\t%.5f' % (
-            metrics_test.accuracy,
-            metrics_test.precision,
-            metrics_test.recall,
-            metrics_test.fscore,
-        ))
+        f.write(
+            f'\t{metrics_test.accuracy:.5f}\t{metrics_test.precision:.5f}\t{metrics_test.recall:.5f}\t{metrics_test.fscore:.5f}'
+        )
 
       f.write('\n')
 
@@ -386,8 +380,9 @@ def main() -> None:
                                                     feature_thres, val_data)
   fit(dataset_train, dataset_val, features, iterations, weights_filename,
       log_filename, out_span)
-  print('Training done. Export the model by passing %s to build_model.py' %
-        (weights_filename))
+  print(
+      f'Training done. Export the model by passing {weights_filename} to build_model.py'
+  )
 
 
 if __name__ == '__main__':

--- a/scripts/translate_model.py
+++ b/scripts/translate_model.py
@@ -79,7 +79,7 @@ def normalize(model: dict[str, typing.Any]) -> dict[str, dict[str, int]]:
         for groups in model.values()
         for v in groups.values())), 'Scores should be integers'
   except (AssertionError, AttributeError) as e:
-    raise Exception('Unsupported model format:', e)
+    raise ValueError(f'Unsupported model format: {e}')
   else:
     return model
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -145,7 +145,6 @@ class TestStdin(unittest.TestCase):
   def test_cmdargs_blank_stdin(self) -> None:
     with open(
         join(abspath(dirname(__file__)), "in/1.in"),
-        "r",
         encoding=sys.getdefaultencoding()) as f:
       sys.stdin = f
       output = main._main([])
@@ -155,7 +154,6 @@ class TestStdin(unittest.TestCase):
   def test_cmdargs_text_stdin(self) -> None:
     with open(
         join(abspath(dirname(__file__)), "in/2.in"),
-        "r",
         encoding=sys.getdefaultencoding()) as f:
       sys.stdin = f
       output = main._main([])
@@ -165,7 +163,6 @@ class TestStdin(unittest.TestCase):
   def test_cmdargs_html_stdin(self) -> None:
     with open(
         join(abspath(dirname(__file__)), "in/3.in"),
-        "r",
         encoding=sys.getdefaultencoding()) as f:
       sys.stdin = f
       output = main._main(["-H"])


### PR DESCRIPTION
Refactored Python codebase to fix several Ruff rules and cleared them from the `ignore` list. Includes fixes for legacy string formatting (UP031), context manager usage (SIM115), type hinting for context managers (PYI), broad exceptions (TRY), and mutable class defaults (RUF012).

---
*PR created automatically by Jules for task [10678952485402196931](https://jules.google.com/task/10678952485402196931) started by @tushuhei*