### PR TITLE
🧪 [testing improvement] Add Missing Error Handling Test in translate_model.py

### DIFF
--- a/scripts/tests/test_translate_model.py
+++ b/scripts/tests/test_translate_model.py
@@ -38,13 +38,20 @@ class TestNormalize(unittest.TestCase):
 
   def test_broken_input1(self) -> None:
     model = {'a:x': 23, 'b': {'x': 37, 'y': 18}}
-    with self.assertRaises(Exception) as cm:
+    with self.assertRaises(ValueError) as cm:
       translate_model.normalize(model)
     self.assertTrue('Unsupported model format' in str(cm.exception))
 
   def test_broken_input2(self) -> None:
     model = {'b': {'x': 37, 'y': {'z': 123}}}
-    with self.assertRaises(Exception) as cm:
+    with self.assertRaises(ValueError) as cm:
+      translate_model.normalize(model)
+    self.assertTrue('Unsupported model format' in str(cm.exception))
+
+  def test_broken_input_attribute_error(self) -> None:
+    # A list does not have a .values() method, which should trigger an AttributeError.
+    model = {'b': ['x', 37]}
+    with self.assertRaises(ValueError) as cm:
       translate_model.normalize(model)
     self.assertTrue('Unsupported model format' in str(cm.exception))
 


### PR DESCRIPTION
🎯 **What:** The testing gap addressed is the lack of explicit testing for `AttributeError` handling within the `normalize()` function in `scripts/translate_model.py`.
📊 **Coverage:** The new scenario now tests passing an object without a `values()` method (such as a list) where a dictionary is expected, confirming that the `except (AssertionError, AttributeError)` block catches it and raises a `ValueError`.
✨ **Result:** Improvement in test coverage, ensuring that changes to normalization structures will correctly fail if malformed input is given, maintaining robustness.

---
*PR created automatically by Jules for task [5075075278882585906](https://jules.google.com/task/5075075278882585906) started by @tushuhei*