### PR TITLE
feat(scripts): add exec_cmd to ColabRunner and simplify remote execution

### DIFF
--- a/scripts/colab_runner.py
+++ b/scripts/colab_runner.py
@@ -20,6 +20,7 @@ file transfer, script execution, and auto-cleanup via Python context managers.
 import os
 import shutil
 import subprocess
+import tempfile
 import typing
 
 
@@ -90,6 +91,7 @@ class ColabRunner:
 
   def provision_session(self) -> None:
     """Provisions a new remote Colab session with specified accelerator."""
+    self._run_cmd(["stop", "-s", self.session_name], check=False)
     cmd = ["new", "-s", self.session_name]
     # TPU variants start with a small 'v' (e.g. v6e1, v5e1), GPUs use --gpu flag
     if self.accelerator.startswith("v"):
@@ -144,6 +146,38 @@ class ColabRunner:
       cmd.extend(["--output-image", output_image])
     print(f"[Colab CLI] Running remote script execution ({script_path})...", flush=True)
     self._run_cmd(cmd)
+
+  def exec_code(
+    self, code: str, output_image: str | None = None, timeout: float = 43200.0
+  ) -> None:
+    """Executes inline Python code remotely on the Colab VM."""
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False) as f:
+      f.write(code)
+      script_path = f.name
+    try:
+      self.exec_script(script_path, output_image=output_image, timeout=timeout)
+    finally:
+      if os.path.exists(script_path):
+        os.remove(script_path)
+
+  def exec_cmd(self, cmd: list[str], timeout: float = 43200.0) -> None:
+    """Executes a shell command remotely on the Colab VM and streams stdout.
+
+    In Colab/Jupyter kernels, commands run via subprocess.run bypass Jupyter's
+    ipykernel.iostream.OutStream handler. By reading p.stdout line-by-line in Python
+    and writing to sys.stdout with immediate flush(), every line routes across the
+    ZeroMQ IOPub socket back to the local CLI client in real time.
+    """
+    code = (
+      "import subprocess, sys\n"
+      f"p = subprocess.Popen({cmd!r}, stdout=subprocess.PIPE,"
+      " stderr=subprocess.STDOUT, text=True)\n"
+      "for line in p.stdout:\n"
+      "    sys.stdout.write(line)\n"
+      "    sys.stdout.flush()\n"
+      "sys.exit(p.wait())\n"
+    )
+    self.exec_code(code, timeout=timeout)
 
   def stop_session(self) -> None:
     """Terminates and cleans up the remote Colab session."""

--- a/scripts/run_training_pipeline.py
+++ b/scripts/run_training_pipeline.py
@@ -156,17 +156,8 @@ def run_retraining_pipeline(
         if os.path.exists(val_encoded):
           remote_args.extend(["--val-data", "/content/val_encoded.txt"])
 
-        with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False) as f:
-          f.write("import subprocess\n")
-          f.write(f"subprocess.run({remote_args!r}, check=True)\n")
-          launcher_path = f.name
-
-        try:
-          runner.exec_script(launcher_path)
-          runner.download_file("/content/weights.txt", weights_path)
-        finally:
-          if os.path.exists(launcher_path):
-            os.remove(launcher_path)
+        runner.exec_cmd(remote_args)
+        runner.download_file("/content/weights.txt", weights_path)
 
     else:
       train_cmd = [

--- a/scripts/tests/test_colab_runner.py
+++ b/scripts/tests/test_colab_runner.py
@@ -94,13 +94,25 @@ class TestColabRunner(unittest.TestCase):
       runner.download_file("remote.txt", "local_out.txt")
 
     self.assertFalse(runner._is_active)
-    # Total of 5 subprocess calls executed in sequence:
-    # 1. new (provision session)
-    # 2. upload_file
-    # 3. exec_script
-    # 4. download_file
-    # 5. stop (cleanup session on context exit)
-    self.assertEqual(mock_run.call_count, 5)
+    # Total of 6 subprocess calls executed in sequence:
+    # 1. stop (cleanup existing session before provisioning)
+    # 2. new (provision session)
+    # 3. upload_file
+    # 4. exec_script
+    # 5. download_file
+    # 6. stop (cleanup session on context exit)
+    self.assertEqual(mock_run.call_count, 6)
+
+  @patch("subprocess.run")
+  def test_exec_cmd(self, mock_run: MagicMock) -> None:
+    runner = colab_runner.ColabRunner(
+      session_name="test-sess", binary_path="/usr/bin/colab"
+    )
+    runner.exec_cmd(["echo", "hello"])
+    self.assertEqual(mock_run.call_count, 1)
+    call_args = mock_run.call_args[0][0]
+    self.assertIn("exec", call_args)
+    self.assertIn("test-sess", call_args)
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_run_training_pipeline.py
+++ b/scripts/tests/test_run_training_pipeline.py
@@ -104,7 +104,7 @@ class TestRunTrainingPipeline(unittest.TestCase):
       mock_colab_runner_cls.assert_called_once_with(
         session_name="budoux-train-T4", accelerator="T4"
       )
-      self.assertTrue(mock_runner.exec_script.called)
+      self.assertTrue(mock_runner.exec_cmd.called)
 
       uploaded_remote_paths = [
         call[0][1] for call in mock_runner.upload_file.call_args_list
@@ -119,7 +119,7 @@ class TestRunTrainingPipeline(unittest.TestCase):
   ) -> None:
     mock_runner = MagicMock()
     mock_colab_runner_cls.return_value.__enter__.return_value = mock_runner
-    mock_runner.exec_script.side_effect = RuntimeError("Remote execution failed")
+    mock_runner.exec_cmd.side_effect = RuntimeError("Remote execution failed")
 
     with tempfile.TemporaryDirectory() as tmp_dir:
       split_dir = os.path.join(tmp_dir, "splits")


### PR DESCRIPTION
- Add exec_code and exec_cmd helper methods to ColabRunner in scripts/colab_runner.py, streaming subprocess stdout via sys.stdout for real-time console metrics.
- Add pre-provision session cleanup (stop_session) in provision_session to clean up orphan Colab VMs and prevent TooManyAssignmentsError.
- Simplify Colab execution in scripts/run_training_pipeline.py by calling runner.exec_cmd(remote_args).
- Add unit test test_exec_cmd in scripts/tests/test_colab_runner.py.

TAG=agy
CONV=da1ee413-f759-43cd-8f2d-90cf430c1f51