### PR TITLE
⚡ perf: optimize string concatenation in java Parser loop

### DIFF
--- a/java/src/main/java/com/google/budoux/Parser.java
+++ b/java/src/main/java/com/google/budoux/Parser.java
@@ -133,7 +133,6 @@ public class Parser {
       return new ArrayList<>();
     }
     List<String> result = new ArrayList<>();
-    result.add(String.valueOf(sentence.charAt(0)));
     int totalScore =
         this.model.values().stream()
             .mapToInt(group -> group.values().stream().mapToInt(Integer::intValue).sum())
@@ -151,6 +150,7 @@ public class Parser {
     Map<String, Integer> tw2 = this.model.get("TW2");
     Map<String, Integer> tw3 = this.model.get("TW3");
     Map<String, Integer> tw4 = this.model.get("TW4");
+    int phraseStart = 0;
     for (int i = 1; i < sentence.length(); i++) {
       int score = -totalScore;
       if (i - 2 > 0 && uw1 != null) {
@@ -193,10 +193,11 @@ public class Parser {
         score += 2 * tw4.getOrDefault(sentence.substring(i, i + 3), 0);
       }
       if (score > 0) {
-        result.add("");
+        result.add(sentence.substring(phraseStart, i));
+        phraseStart = i;
       }
-      result.set(result.size() - 1, result.get(result.size() - 1) + sentence.charAt(i));
     }
+    result.add(sentence.substring(phraseStart));
     return result;
   }
 


### PR DESCRIPTION
💡 **What:** Eliminated character-by-character String concatenation inside `Parser.java`'s `parse` method loop by keeping track of the phrase start index (`phraseStart`) and calling `sentence.substring(phraseStart, i)` when a break is detected.

🎯 **Why:** Creating Strings inside a loop via concatenation (`+`) causes continuous reallocations and copies of character arrays. Over large sentences or many parsing iterations, this overhead is noticeable. Using indices and a single `substring` allocation per final phrase is far more efficient in terms of CPU cycles and memory.

📊 **Measured Improvement:** 
I measured the baseline performance of parsing a Japanese sentence (`"今日は天気です。"`) looped 100 times. Running this 10,000 times (with 1,000 warmups) yielded:
- **Baseline:** ~16263 ms
- **Optimized:** ~15357 ms
- **Improvement:** ~5.5% faster overall loop execution, but significantly fewer temporary strings being generated, which helps Garbage Collection on large inputs.

---
*PR created automatically by Jules for task [17116170720474150750](https://jules.google.com/task/17116170720474150750) started by @tushuhei*