### PR TITLE
🔒 Secure tarball extraction to prevent path traversal

### DIFF
--- a/scripts/run_training_pipeline.py
+++ b/scripts/run_training_pipeline.py
@@ -56,15 +56,7 @@ def run_retraining_pipeline(
       tar_path = os.path.join(tmp_knbc, "knbc.tar.bz2")
       urllib.request.urlretrieve(KNBC_URL, tar_path)
       with tarfile.open(tar_path, "r:bz2") as tar:
-        if hasattr(tarfile, "data_filter"):
-          tar.extractall(path=tmp_knbc, filter="data")
-        else:
-          abs_out = os.path.abspath(tmp_knbc)
-          for member in tar.getmembers():
-            member_path = os.path.abspath(os.path.join(abs_out, member.name))
-            if os.path.commonpath([abs_out, member_path]) != abs_out:
-              raise ValueError(f"Insecure member in tar file: {member.name}")
-          tar.extractall(path=tmp_knbc)
+        tar.extractall(path=tmp_knbc, filter="data")
       source_dir = os.path.join(tmp_knbc, "KNBC_v1.0_090925_utf8")
       outfile = os.path.join(tmp_knbc, "source_knbc.txt")
       subprocess.run(

--- a/scripts/run_training_pipeline.py
+++ b/scripts/run_training_pipeline.py
@@ -56,7 +56,15 @@ def run_retraining_pipeline(
       tar_path = os.path.join(tmp_knbc, "knbc.tar.bz2")
       urllib.request.urlretrieve(KNBC_URL, tar_path)
       with tarfile.open(tar_path, "r:bz2") as tar:
-        tar.extractall(path=tmp_knbc)
+        if hasattr(tarfile, "data_filter"):
+          tar.extractall(path=tmp_knbc, filter="data")
+        else:
+          abs_out = os.path.abspath(tmp_knbc)
+          for member in tar.getmembers():
+            member_path = os.path.abspath(os.path.join(abs_out, member.name))
+            if os.path.commonpath([abs_out, member_path]) != abs_out:
+              raise ValueError(f"Insecure member in tar file: {member.name}")
+          tar.extractall(path=tmp_knbc)
       source_dir = os.path.join(tmp_knbc, "KNBC_v1.0_090925_utf8")
       outfile = os.path.join(tmp_knbc, "source_knbc.txt")
       subprocess.run(


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed is an insecure extraction of untrusted tar files via `tarfile.extractall` in `scripts/run_training_pipeline.py`.
⚠️ **Risk:** If a malicious user intercepted the URL fetch or otherwise provided a crafted tarball containing path traversal payloads (e.g. `../` or absolute paths in member filenames), arbitrary files on the local filesystem could be overwritten.
🛡️ **Solution:** The script now explicitly passes `filter="data"` to `tar.extractall()`, opting into Python's built-in defense against path traversal, which safely strips dangerous components from member paths.

---
*PR created automatically by Jules for task [4915335782833203782](https://jules.google.com/task/4915335782833203782) started by @tushuhei*