### PR TITLE
Bump to v0.9.1

### DIFF
--- a/budoux/__init__.py
+++ b/budoux/__init__.py
@@ -15,7 +15,7 @@
 
 from . import parser
 
-__version__ = "0.9.0"
+__version__ = "0.9.1"
 
 Parser = parser.Parser
 load_default_japanese_parser = parser.load_default_japanese_parser

--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -19,7 +19,7 @@
     },
     "../javascript": {
       "name": "budoux",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "Apache-2.0",
       "dependencies": {
         "commander": "^15.0.0",

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -20,7 +20,7 @@
 
   <groupId>com.google.budoux</groupId>
   <artifactId>budoux</artifactId>
-  <version>0.9.0</version>
+  <version>0.9.1</version>
 
   <name>BudouX</name>
   <description>BudouX: A standalone, small, and language-neutral segmenter library</description>

--- a/javascript/package-lock.json
+++ b/javascript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "budoux",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "budoux",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "Apache-2.0",
       "dependencies": {
         "commander": "^15.0.0",

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "budoux",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "A small chunk segmenter.",
   "author": "Shuhei Iitsuka",
   "license": "Apache-2.0",

--- a/javascript/src/cli.ts
+++ b/javascript/src/cli.ts
@@ -24,7 +24,7 @@ import {
   loadDefaultParsers,
 } from './index.js';
 
-const CLI_VERSION = '0.9.0';
+const CLI_VERSION = '0.9.1';
 const defaultParsers = loadDefaultParsers();
 
 /**


### PR DESCRIPTION
Prepares the v0.9.1 release by updating version strings across Python, JavaScript, and Java packages and lockfiles.

---
*PR created automatically by Jules for task [4652187129832861626](https://jules.google.com/task/4652187129832861626) started by @tushuhei*