### PR TITLE
feat(js): support DocumentFragment in HTMLProcessor (#273)

### DIFF
--- a/javascript/src/html_processor.ts
+++ b/javascript/src/html_processor.ts
@@ -27,6 +27,7 @@ const ZWSP = String.fromCharCode(ZWSP_CODEPOINT);
 const NodeType = {
   ELEMENT_NODE: 1,
   TEXT_NODE: 3,
+  DOCUMENT_FRAGMENT_NODE: 11,
 };
 
 const DomAction = {
@@ -177,11 +178,15 @@ function actionForDisplay(display: string): DomAction {
 }
 
 /**
- * Determine the action for an element.
- * @param element An element to determine the action for.
+ * Determine the action for an element or document fragment.
+ * @param element An element or document fragment to determine the action for.
  * @return The {@link domActions} for the element.
  */
-function actionForElement(element: Element): DomAction {
+function actionForElement(element: Element | DocumentFragment): DomAction {
+  if (isDocumentFragment(element)) {
+    return DomAction.Block;
+  }
+
   const nodeName = element.nodeName;
   const action = domActions[nodeName];
   if (action !== undefined) return action;
@@ -284,6 +289,12 @@ class NodeOrText {
 }
 export class NodeOrTextForTesting extends NodeOrText {}
 
+function isDocumentFragment(
+  node: Element | DocumentFragment
+): node is DocumentFragment {
+  return node.nodeType === NodeType.DOCUMENT_FRAGMENT_NODE;
+}
+
 /**
  * Represents a "paragraph", broken by block boundaries or forced breaks.
  *
@@ -293,10 +304,10 @@ export class NodeOrTextForTesting extends NodeOrText {}
  * forced breaks such as `<br>`.
  */
 class Paragraph {
-  element: HTMLElement;
+  element: HTMLElement | DocumentFragment;
   nodes: NodeOrText[] = [];
 
-  constructor(element: HTMLElement) {
+  constructor(element: HTMLElement | DocumentFragment) {
     this.element = element;
   }
 
@@ -404,7 +415,7 @@ export class HTMLProcessor {
    * @param ele An element to be checked.
    * @return Whether the element has a child text node.
    */
-  static hasChildTextNode(ele: HTMLElement) {
+  static hasChildTextNode(ele: HTMLElement | DocumentFragment) {
     for (const child of ele.childNodes) {
       if (child.nodeType === NodeType.TEXT_NODE) return true;
     }
@@ -412,13 +423,13 @@ export class HTMLProcessor {
   }
 
   /**
-   * Applies markups for semantic line breaks to the given HTML element.
+   * Applies markups for semantic line breaks to the given HTML element or document fragment.
    *
    * It breaks descendant nodes into paragraphs,
    * and applies the BudouX to each paragraph.
-   * @param element The input element.
+   * @param element The input element or document fragment.
    */
-  applyToElement(element: HTMLElement) {
+  applyToElement(element: HTMLElement | DocumentFragment) {
     for (const block of this.getBlocks(element)) {
       assert(!block.isEmpty());
       this.applyToParagraph(block);
@@ -426,19 +437,27 @@ export class HTMLProcessor {
   }
 
   /**
-   * Find paragraphs from a given HTML element.
-   * @param element The root element to find paragraphs.
+   * Find paragraphs from a given HTML element or document fragment.
+   * @param element The root element or document fragment to find paragraphs.
    * @param parent The parent {@link Paragraph} if any.
    * @return A list of {@link Paragraph}s.
    */
   *getBlocks(
-    element: HTMLElement,
+    element: HTMLElement | DocumentFragment,
     parent?: Paragraph
   ): IterableIterator<Paragraph> {
-    assert(element.nodeType === NodeType.ELEMENT_NODE);
+    assert(
+      element.nodeType === NodeType.ELEMENT_NODE ||
+        element.nodeType === NodeType.DOCUMENT_FRAGMENT_NODE
+    );
 
     // Skip if it was once applied to this element.
-    if (this.className && element.classList.contains(this.className)) return;
+    if (
+      !isDocumentFragment(element) &&
+      this.className &&
+      element.classList.contains(this.className)
+    )
+      return;
 
     const action = actionForElement(element);
     if (action === DomAction.Skip) return;
@@ -598,10 +617,22 @@ export class HTMLProcessor {
   }
 
   /**
-   * Applies the block style to the given element.
-   * @param element The element to apply the block style.
+   * Applies the block style to the given element or document fragment.
+   * @param element The element or document fragment to apply the block style.
    */
-  applyBlockStyle(element: HTMLElement): void {
+  applyBlockStyle(element: HTMLElement | DocumentFragment): void {
+    if (isDocumentFragment(element)) {
+      if (HTMLProcessor.hasChildTextNode(element)) {
+        const doc = element.ownerDocument;
+        if (doc) {
+          const wrapper = doc.createElement('span') as unknown as HTMLElement;
+          wrapper.append(...Array.from(element.childNodes));
+          element.append(wrapper);
+          this.applyBlockStyle(wrapper);
+        }
+      }
+      return;
+    }
     if (this.className) {
       element.classList.add(this.className);
       return;
@@ -627,10 +658,10 @@ export class HTMLProcessingParser extends Parser {
   }
 
   /**
-   * Applies markups for semantic line breaks to the given HTML element.
-   * @param parentElement The input element.
+   * Applies markups for semantic line breaks to the given HTML element or document fragment.
+   * @param parentElement The input element or document fragment.
    */
-  applyToElement(parentElement: HTMLElement) {
+  applyToElement(parentElement: HTMLElement | DocumentFragment) {
     this.htmlProcessor.applyToElement(parentElement);
   }
 

--- a/javascript/src/tests/test_html_processor.ts
+++ b/javascript/src/tests/test_html_processor.ts
@@ -535,3 +535,95 @@ describe('HTMLProcessingParser.translateHTMLString', () => {
     checkEqual(defaultModel, inputHTML, expectedHTML);
   });
 });
+
+describe('HTMLProcessingParser.applyToElement with DocumentFragment', () => {
+  const defaultModel = {
+    UW4: {a: 1001},
+  };
+
+  it('should support applyToElement with a DocumentFragment containing elements.', () => {
+    const parser = new HTMLProcessingParser(defaultModel);
+    const doc = createDocument();
+    const fragment = doc.createDocumentFragment();
+    const p = doc.createElement('p');
+    p.textContent = 'xyzabcd';
+    fragment.appendChild(p);
+    parser.applyToElement(fragment);
+    expect(fragment.childNodes.length).toBe(1);
+    expect(fragment.firstElementChild).toBe(p);
+    expect(p.style.wordBreak).toBe('keep-all');
+    expect(p.innerHTML).toBe('xyz\u200Babcd');
+  });
+
+  it('should handle multiple block elements without wrapping the fragment in a span.', () => {
+    const parser = new HTMLProcessingParser(defaultModel);
+    const doc = createDocument();
+    const fragment = doc.createDocumentFragment();
+    const p1 = doc.createElement('p');
+    p1.textContent = 'xyzabcd';
+    const p2 = doc.createElement('p');
+    p2.textContent = 'xyzabcd';
+    fragment.appendChild(p1);
+    fragment.appendChild(p2);
+    parser.applyToElement(fragment);
+    expect(fragment.childNodes.length).toBe(2);
+    expect(fragment.childNodes[0]).toBe(p1);
+    expect(fragment.childNodes[1]).toBe(p2);
+    expect(p1.style.wordBreak).toBe('keep-all');
+    expect(p1.innerHTML).toBe('xyz\u200Babcd');
+    expect(p2.style.wordBreak).toBe('keep-all');
+    expect(p2.innerHTML).toBe('xyz\u200Babcd');
+  });
+
+  it('should wrap top-level text nodes in a span when applied to a DocumentFragment.', () => {
+    const parser = new HTMLProcessingParser(defaultModel);
+    const doc = createDocument();
+    const fragment = doc.createDocumentFragment();
+    fragment.appendChild(doc.createTextNode('xyzabcd'));
+    parser.applyToElement(fragment);
+    expect(fragment.childNodes.length).toBe(1);
+    const span = fragment.firstElementChild as HTMLElement;
+    expect(span.tagName.toLowerCase()).toBe('span');
+    expect(span.style.wordBreak).toBe('keep-all');
+    expect(span.innerHTML).toBe('xyz\u200Babcd');
+  });
+
+  it('should wrap mixed top-level text and elements in a span.', () => {
+    const parser = new HTMLProcessingParser(defaultModel);
+    const doc = createDocument();
+    const fragment = doc.createDocumentFragment();
+    fragment.appendChild(doc.createTextNode('xyz'));
+    const strong = doc.createElement('strong');
+    strong.textContent = 'abcd';
+    fragment.appendChild(strong);
+    parser.applyToElement(fragment);
+    expect(fragment.childNodes.length).toBe(1);
+    const span = fragment.firstElementChild as HTMLElement;
+    expect(span.tagName.toLowerCase()).toBe('span');
+    expect(span.style.wordBreak).toBe('keep-all');
+    expect(span.innerHTML).toBe('xyz<strong>\u200Babcd</strong>');
+  });
+
+  it('should handle an empty DocumentFragment gracefully.', () => {
+    const parser = new HTMLProcessingParser(defaultModel);
+    const doc = createDocument();
+    const fragment = doc.createDocumentFragment();
+    parser.applyToElement(fragment);
+    expect(fragment.childNodes.length).toBe(0);
+  });
+
+  it('should apply className instead of inline style when configured.', () => {
+    const parser = new HTMLProcessingParser(defaultModel, {
+      className: 'budoux-applied',
+    });
+    const doc = createDocument();
+    const fragment = doc.createDocumentFragment();
+    const p = doc.createElement('p');
+    p.textContent = 'xyzabcd';
+    fragment.appendChild(p);
+    parser.applyToElement(fragment);
+    expect(p.classList.contains('budoux-applied')).toBe(true);
+    expect(p.getAttribute('style')).toBeNull();
+    expect(p.innerHTML).toBe('xyz\u200Babcd');
+  });
+});


### PR DESCRIPTION
This PR adds support for `DocumentFragment` to `HTMLProcessor.applyToElement` and `HTMLProcessingParser.applyToElement`, resolving #273.

Previously, `applyToElement` strictly required an `HTMLElement` (`nodeType === 1`). Calling it on a `DocumentFragment` (`nodeType === 11`) failed assertions and caused runtime errors when attempting to access properties like `.style` or `classList`.

### Key Benefits

1. **Eliminate Redundant Serialization & Parsing Cycles**
   When processing DOM nodes (such as `<template>.content` in Web Components or offscreen nodes), consumers were previously forced to serialize them to strings via `innerHTML`, run `translateHTMLString` (which parses HTML back into a DOM tree, mutates it, and re-serializes it to a string), and then parse the string again into the DOM. With `DocumentFragment` support, callers can manipulate and pass DOM fragments directly with zero serialization/parsing overhead.

2. **Reflow & Layout Preservation (No Dummy Wrapper Elements)**
   To apply BudouX offscreen to multiple sibling elements (e.g. for CSS Grid or Flexbox containers), developers previously had to wrap them inside a dummy container like `<div>` or `<span>`. This contaminated the DOM structure and often broke CSS parent-child rules (`display: flex > *`). Because appending a `DocumentFragment` to the DOM unwraps its children atomically, developers can now prepare and process elements offscreen in batch, inserting them with a single reflow without unwanted wrapper nodes.

3. **Compatibility with Strict Security / Trusted Types Environments**
   Modifying and inserting `DocumentFragment` via `appendChild` / `replaceChildren` avoids `innerHTML` / `dangerouslySetInnerHTML` sinks entirely, making BudouX much easier to use in environments enforcing CSP Trusted Types.

---

### Example

#### Using with `<template>` in Web Components / Modern UI

```typescript
import { loadDefaultJapaneseParser } from 'budoux';
const parser = loadDefaultJapaneseParser();

const template = document.getElementById('card-template') as HTMLTemplateElement;

function renderCard(titleText: string, descText: string) {
  // template.content.cloneNode(true) returns a DocumentFragment
  const fragment = template.content.cloneNode(true) as DocumentFragment;

  fragment.querySelector('.title')!.textContent = titleText;
  fragment.querySelector('.desc')!.textContent = descText;

  // Previously: Threw assertion error (nodeType !== 1).
  // Now: Directly applies semantic word breaks to the fragment!
  parser.applyToElement(fragment);

  // Atomically inserted without extra wrapper elements or innerHTML assignment
  document.getElementById('cards-grid')!.appendChild(fragment);
}